### PR TITLE
Fix warning message in function pg_decode_commit_txn:297

### DIFF
--- a/wal2json.c
+++ b/wal2json.c
@@ -294,7 +294,8 @@ pg_decode_commit_txn(LogicalDecodingContext *ctx, ReorderBufferTXN *txn,
 		elog(DEBUG1, "txn has catalog changes: yes");
 	else
 		elog(DEBUG1, "txn has catalog changes: no");
-	elog(DEBUG1, "my change counter: %lu ; # of changes: %lu ; # of changes in memory: %lu", data->nr_changes, txn->nentries, txn->nentries_mem);
+	elog(DEBUG1, "my change counter: %llu ; # of changes: %llu ; # of changes in memory: %llu",
+		 data->nr_changes, txn->nentries, txn->nentries_mem);
 	elog(DEBUG1, "# of subxacts: %d", txn->nsubtxns);
 
 	/* Transaction ends */


### PR DESCRIPTION
Fix warning message in function pg_decode_commit_txn:297

n# make USE_PGXS=1
gcc -Wall -Wmissing-prototypes -Wpointer-arith -Wdeclaration-after-statement -Wendif-labels -Wmissing-format-attribute -Wformat-security -fno-strict-aliasing -fwrapv -fexcess-precision=standard -g -g -O2 -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -I/usr/include/mit-krb5 -DLINUX_OOM_SCORE_ADJ=0 -fpic -I. -I./ -I/usr/include/postgresql/9.4/server -I/usr/include/postgresql/internal -D_FORTIFY_SOURCE=2 -D_GNU_SOURCE -I/usr/include/libxml2  -I/usr/include/tcl8.6  -c -o wal2json.o wal2json.c
wal2json.c: In function ‘pg_decode_commit_txn’:
wal2json.c:297:2: warning: format ‘%d’ expects argument of type ‘int’, but argument 3 has type ‘uint64’ [-Wformat=]
  elog(DEBUG1, "my change counter: %d ; # of changes: %d ; # of changes in memory: %d", data->nr_changes, txn->nentries, txn->nentries_mem);
  ^
wal2json.c:297:2: warning: format ‘%d’ expects argument of type ‘int’, but argument 4 has type ‘uint64’ [-Wformat=]
wal2json.c:297:2: warning: format ‘%d’ expects argument of type ‘int’, but argument 5 has type ‘uint64’ [-Wformat=]
gcc -Wall -Wmissing-prototypes -Wpointer-arith -Wdeclaration-after-statement -Wendif-labels -Wmissing-format-attribute -Wformat-security -fno-strict-aliasing -fwrapv -fexcess-precision=standard -g -g -O2 -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -I/usr/include/mit-krb5 -DLINUX_OOM_SCORE_ADJ=0 -fpic -L/usr/lib/i386-linux-gnu -Wl,-Bsymbolic-functions -Wl,-z,relro -Wl,-z,now -Wl,--as-needed -L/usr/lib/mit-krb5 -L/usr/lib/i386-linux-gnu/mit-krb5  -Wl,--as-needed  -shared -o wal2json.so wal2json.o
