### PR TITLE
Give an error instead of a warning in case of bad param

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 MODULES = wal2json
 
-REGRESS = insert1 update1 update2 update3 update4 delete1 delete2 \
+REGRESS = cmdline insert1 update1 update2 update3 update4 delete1 delete2 \
 		  delete3 delete4 savepoint specialvalue toast bytea
 
 PG_CONFIG = pg_config

--- a/expected/cmdline.out
+++ b/expected/cmdline.out
@@ -8,7 +8,7 @@ SELECT 'init' FROM pg_create_logical_replication_slot('regression_slot', 'wal2js
 (1 row)
 
 SELECT data FROM pg_logical_slot_get_changes('regression_slot', NULL, NULL, 'nosuchopt', '42');
-ERROR:  unknown parameter nosuchopt = 42
+ERROR:  option "nosuchopt" = "42" is unknown
 SELECT 'stop' FROM pg_drop_replication_slot('regression_slot');
  ?column? 
 ----------

--- a/expected/cmdline.out
+++ b/expected/cmdline.out
@@ -1,0 +1,17 @@
+\set VERBOSITY terse
+-- predictability
+SET synchronous_commit = on;
+SELECT 'init' FROM pg_create_logical_replication_slot('regression_slot', 'wal2json');
+ ?column? 
+----------
+ init
+(1 row)
+
+SELECT data FROM pg_logical_slot_get_changes('regression_slot', NULL, NULL, 'nosuchopt', '42');
+ERROR:  unknown parameter nosuchopt = 42
+SELECT 'stop' FROM pg_drop_replication_slot('regression_slot');
+ ?column? 
+----------
+ stop
+(1 row)
+

--- a/sql/cmdline.sql
+++ b/sql/cmdline.sql
@@ -1,0 +1,10 @@
+\set VERBOSITY terse
+
+-- predictability
+SET synchronous_commit = on;
+
+SELECT 'init' FROM pg_create_logical_replication_slot('regression_slot', 'wal2json');
+
+SELECT data FROM pg_logical_slot_get_changes('regression_slot', NULL, NULL, 'nosuchopt', '42');
+
+SELECT 'stop' FROM pg_drop_replication_slot('regression_slot');

--- a/wal2json.c
+++ b/wal2json.c
@@ -215,7 +215,7 @@ pg_decode_startup(LogicalDecodingContext *ctx, OutputPluginOptions *opt, bool is
 		else
 			ereport(ERROR,
 					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-					 errmsg("unknown parameter %s = %s",
+					 errmsg("option \"%s\" = \"%s\" is unknown",
 						elem->defname,
 						elem->arg ? strVal(elem->arg) : "(null)")));
 	}

--- a/wal2json.c
+++ b/wal2json.c
@@ -213,10 +213,11 @@ pg_decode_startup(LogicalDecodingContext *ctx, OutputPluginOptions *opt, bool is
 							 strVal(elem->arg), elem->defname)));
 		}
 		else
-		{
-			elog(WARNING, "option %s = %s is unknown",
-				 elem->defname, elem->arg ? strVal(elem->arg) : "(null)");
-		}
+			ereport(ERROR,
+					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+					 errmsg("unknown parameter %s = %s",
+						elem->defname,
+						elem->arg ? strVal(elem->arg) : "(null)")));
 	}
 }
 


### PR DESCRIPTION
I think in case of unknown parameter the program shouldn't run. Better an error upfront than running with wrong parameters (maybe something was misspelled?)