### PR TITLE
Skip empty xacts

### DIFF
--- a/expected/delete1.out
+++ b/expected/delete1.out
@@ -64,6 +64,9 @@ UNIQUE(g, n)
 INSERT INTO table_with_pk (b, c, d, e, f, g, h, i, j, k, l, m, n, o, p) VALUES(1, 2, 3, 3.54, 876.563452345, 1.23, 'teste', 'testando', 'um texto longo', B'001110010101010', '2013-11-02 17:30:52', '2013-02-04', true, '{ "a": 123 }', 'Old Old Parr'::tsvector);
 INSERT INTO table_without_pk (b, c, d, e, f, g, h, i, j, k, l, m, n, o, p) VALUES(1, 2, 3, 3.54, 876.563452345, 1.23, 'teste', 'testando', 'um texto longo', B'001110010101010', '2013-11-02 17:30:52', '2013-02-04', true, '{ "a": 123 }', 'Old Old Parr'::tsvector);
 INSERT INTO table_with_unique (b, c, d, e, f, g, h, i, j, k, l, m, n, o, p) VALUES(1, 2, 3, 3.54, 876.563452345, 1.23, 'teste', 'testando', 'um texto longo', B'001110010101010', '2013-11-02 17:30:52', '2013-02-04', true, '{ "a": 123 }', 'Old Old Parr'::tsvector);
+INSERT INTO table_with_pk (b, c, d, e, f, g, h, i, j, k, l, m, n, o, p) VALUES(2, 2, 3, 3.54, 876.563452345, 1.23, 'teste', 'testando', 'um texto longo', B'001110010101010', '2013-11-02 17:30:52', '2013-02-04', false, '{ "a": 123 }', 'Old Old Parr'::tsvector);
+INSERT INTO table_without_pk (b, c, d, e, f, g, h, i, j, k, l, m, n, o, p) VALUES(2, 2, 3, 3.54, 876.563452345, 1.23, 'teste', 'testando', 'um texto longo', B'001110010101010', '2013-11-02 17:30:52', '2013-02-04', false, '{ "a": 123 }', 'Old Old Parr'::tsvector);
+INSERT INTO table_with_unique (b, c, d, e, f, g, h, i, j, k, l, m, n, o, p) VALUES(2, 2, 3, 3.54, 876.563452345, 1.23, 'teste', 'testando', 'um texto longo', B'001110010101010', '2013-11-02 17:30:52', '2013-02-04', false, '{ "a": 123 }', 'Old Old Parr'::tsvector);
 SELECT 'init' FROM pg_create_logical_replication_slot('regression_slot', 'wal2json');
  ?column? 
 ----------
@@ -104,6 +107,31 @@ WARNING:  table "table_with_unique" without primary key or replica identity is n
          ]                                                            +
  }
 (7 rows)
+
+-- Again, hiding empty xacts
+DELETE FROM table_without_pk WHERE b = 2;
+DELETE FROM table_with_pk WHERE b = 2;
+DELETE FROM table_with_unique WHERE b = 2;
+SELECT data FROM pg_logical_slot_get_changes('regression_slot', NULL, NULL, 'include-xids', '0', 'pretty-print', '1', 'skip-empty-xacts', '1');
+WARNING:  table "table_without_pk" without primary key or replica identity is nothing
+WARNING:  table "table_with_unique" without primary key or replica identity is nothing
+                                 data                                  
+-----------------------------------------------------------------------
+ {                                                                    +
+         "change": [
+                 {                                                    +
+                         "kind": "delete",                            +
+                         "schema": "public",                          +
+                         "table": "table_with_pk",                    +
+                         "oldkeys": {                                 +
+                                 "keynames": ["b", "c", "d"],         +
+                                 "keytypes": ["int2", "int4", "int8"],+
+                                 "keyvalues": [2, 2, 3]               +
+                         }                                            +
+                 }
+         ]                                                            +
+ }
+(3 rows)
 
 SELECT 'stop' FROM pg_drop_replication_slot('regression_slot');
  ?column? 

--- a/expected/delete1.out
+++ b/expected/delete1.out
@@ -112,7 +112,7 @@ WARNING:  table "table_with_unique" without primary key or replica identity is n
 DELETE FROM table_without_pk WHERE b = 2;
 DELETE FROM table_with_pk WHERE b = 2;
 DELETE FROM table_with_unique WHERE b = 2;
-SELECT data FROM pg_logical_slot_get_changes('regression_slot', NULL, NULL, 'include-xids', '0', 'pretty-print', '1', 'skip-empty-xacts', '1');
+SELECT data FROM pg_logical_slot_get_changes('regression_slot', NULL, NULL, 'include-xids', '0', 'pretty-print', '1', 'include-empty-xacts', '0');
 WARNING:  table "table_without_pk" without primary key or replica identity is nothing
 WARNING:  table "table_with_unique" without primary key or replica identity is nothing
                                  data                                  

--- a/expected/delete2.out
+++ b/expected/delete2.out
@@ -134,7 +134,7 @@ ALTER TABLE table_without_pk REPLICA IDENTITY DEFAULT;
 ALTER TABLE table_with_unique REPLICA IDENTITY NOTHING;
 DELETE FROM table_with_unique WHERE b = 1;
 ALTER TABLE table_with_unique REPLICA IDENTITY DEFAULT;
-SELECT data FROM pg_logical_slot_get_changes('regression_slot', NULL, NULL, 'include-xids', '0', 'pretty-print', '1', 'skip-empty-xacts', '1');
+SELECT data FROM pg_logical_slot_get_changes('regression_slot', NULL, NULL, 'include-xids', '0', 'pretty-print', '1', 'include-empty-xacts', '0');
  data 
 ------
 (0 rows)

--- a/expected/delete2.out
+++ b/expected/delete2.out
@@ -124,6 +124,21 @@ WARNING:  table "table_with_unique" without primary key or replica identity is n
  }
 (18 rows)
 
+-- Test skipping empty xacts
+ALTER TABLE table_with_pk REPLICA IDENTITY NOTHING;
+DELETE FROM table_with_pk WHERE b = 1;
+ALTER TABLE table_with_pk REPLICA IDENTITY DEFAULT;
+ALTER TABLE table_without_pk REPLICA IDENTITY NOTHING;
+DELETE FROM table_without_pk WHERE b = 1;
+ALTER TABLE table_without_pk REPLICA IDENTITY DEFAULT;
+ALTER TABLE table_with_unique REPLICA IDENTITY NOTHING;
+DELETE FROM table_with_unique WHERE b = 1;
+ALTER TABLE table_with_unique REPLICA IDENTITY DEFAULT;
+SELECT data FROM pg_logical_slot_get_changes('regression_slot', NULL, NULL, 'include-xids', '0', 'pretty-print', '1', 'skip-empty-xacts', '1');
+ data 
+------
+(0 rows)
+
 SELECT 'stop' FROM pg_drop_replication_slot('regression_slot');
  ?column? 
 ----------

--- a/expected/delete3.out
+++ b/expected/delete3.out
@@ -167,6 +167,95 @@ SELECT data FROM pg_logical_slot_get_changes('regression_slot', NULL, NULL, 'inc
  }
 (24 rows)
 
+-- Test skipping empty xacts
+SELECT 'stop' FROM pg_drop_replication_slot('regression_slot');
+ ?column? 
+----------
+ stop
+(1 row)
+
+INSERT INTO table_with_pk (b, c, d, e, f, g, h, i, j, k, l, m, n, o, p) VALUES(1, 2, 3, 3.54, 876.563452345, 1.23, 'teste', 'testando', 'um texto longo', B'001110010101010', '2013-11-02 17:30:52', '2013-02-04', true, '{ "a": 123 }', 'Old Old Parr'::tsvector);
+INSERT INTO table_with_pk (b, c, d, e, f, g, h, i, j, k, l, m, n, o, p) VALUES(4, 5, 6, 3.54, 876.563452345, 1.23, 'teste', 'testando', 'um texto longo', B'001110010101010', '2013-11-02 17:30:52', '2013-02-04', true, '{ "a": 123 }', 'Old Old Parr'::tsvector);
+INSERT INTO table_without_pk (b, c, d, e, f, g, h, i, j, k, l, m, n, o, p) VALUES(1, 2, 3, 3.54, 876.563452345, 1.23, 'teste', 'testando', 'um texto longo', B'001110010101010', '2013-11-02 17:30:52', '2013-02-04', true, '{ "a": 123 }', 'Old Old Parr'::tsvector);
+INSERT INTO table_with_unique (b, c, d, e, f, g, h, i, j, k, l, m, n, o, p) VALUES(1, 2, 3, 3.54, 876.563452345, 1.23, 'teste', 'testando', 'um texto longo', B'001110010101010', '2013-11-02 17:30:52', '2013-02-04', true, '{ "a": 123 }', 'Old Old Parr'::tsvector);
+SELECT 'init' FROM pg_create_logical_replication_slot('regression_slot', 'wal2json');
+ ?column? 
+----------
+ init
+(1 row)
+
+-- DELETE: REPLICA IDENTITY FULL
+ALTER TABLE table_with_pk REPLICA IDENTITY FULL;
+DELETE FROM table_with_pk WHERE b = 1;
+DELETE FROM table_with_pk WHERE n = true;
+ALTER TABLE table_with_pk REPLICA IDENTITY DEFAULT;
+ALTER TABLE table_without_pk REPLICA IDENTITY FULL;
+DELETE FROM table_without_pk WHERE b = 1;
+ALTER TABLE table_without_pk REPLICA IDENTITY DEFAULT;
+ALTER TABLE table_with_unique REPLICA IDENTITY FULL;
+DELETE FROM table_with_unique WHERE b = 1;
+ALTER TABLE table_with_unique REPLICA IDENTITY DEFAULT;
+SELECT data FROM pg_logical_slot_get_changes('regression_slot', NULL, NULL, 'include-xids', '0', 'pretty-print', '1', 'skip-empty-xacts', '1');
+                                                                                                               data                                                                                                               
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {                                                                                                                                                                                                                               +
+         "change": [
+                 {                                                                                                                                                                                                               +
+                         "kind": "delete",                                                                                                                                                                                       +
+                         "schema": "public",                                                                                                                                                                                     +
+                         "table": "table_with_pk",                                                                                                                                                                               +
+                         "oldkeys": {                                                                                                                                                                                            +
+                                 "keynames": ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p"],                                                                                                   +
+                                 "keytypes": ["int2", "int2", "int4", "int8", "numeric", "float4", "float8", "bpchar", "varchar", "text", "varbit", "timestamp", "date", "bool", "json", "tsvector"],                            +
+                                 "keyvalues": [3, 1, 2, 3, 3.540, 876.563, 1.23, "teste     ", "testando", "um texto longo", "001110010101010", "Sat Nov 02 17:30:52 2013", "02-04-2013", true, "{ \"a\": 123 }", "'Old' 'Parr'"]+
+                         }                                                                                                                                                                                                       +
+                 }
+         ]                                                                                                                                                                                                                       +
+ }
+ {                                                                                                                                                                                                                               +
+         "change": [
+                 {                                                                                                                                                                                                               +
+                         "kind": "delete",                                                                                                                                                                                       +
+                         "schema": "public",                                                                                                                                                                                     +
+                         "table": "table_with_pk",                                                                                                                                                                               +
+                         "oldkeys": {                                                                                                                                                                                            +
+                                 "keynames": ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p"],                                                                                                   +
+                                 "keytypes": ["int2", "int2", "int4", "int8", "numeric", "float4", "float8", "bpchar", "varchar", "text", "varbit", "timestamp", "date", "bool", "json", "tsvector"],                            +
+                                 "keyvalues": [4, 4, 5, 6, 3.540, 876.563, 1.23, "teste     ", "testando", "um texto longo", "001110010101010", "Sat Nov 02 17:30:52 2013", "02-04-2013", true, "{ \"a\": 123 }", "'Old' 'Parr'"]+
+                         }                                                                                                                                                                                                       +
+                 }
+         ]                                                                                                                                                                                                                       +
+ }
+ {                                                                                                                                                                                                                               +
+         "change": [
+                 {                                                                                                                                                                                                               +
+                         "kind": "delete",                                                                                                                                                                                       +
+                         "schema": "public",                                                                                                                                                                                     +
+                         "table": "table_without_pk",                                                                                                                                                                            +
+                         "oldkeys": {                                                                                                                                                                                            +
+                                 "keynames": ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p"],                                                                                                   +
+                                 "keytypes": ["int2", "int2", "int4", "int8", "numeric", "float4", "float8", "bpchar", "varchar", "text", "varbit", "timestamp", "date", "bool", "json", "tsvector"],                            +
+                                 "keyvalues": [2, 1, 2, 3, 3.540, 876.563, 1.23, "teste     ", "testando", "um texto longo", "001110010101010", "Sat Nov 02 17:30:52 2013", "02-04-2013", true, "{ \"a\": 123 }", "'Old' 'Parr'"]+
+                         }                                                                                                                                                                                                       +
+                 }
+         ]                                                                                                                                                                                                                       +
+ }
+ {                                                                                                                                                                                                                               +
+         "change": [
+                 {                                                                                                                                                                                                               +
+                         "kind": "delete",                                                                                                                                                                                       +
+                         "schema": "public",                                                                                                                                                                                     +
+                         "table": "table_with_unique",                                                                                                                                                                           +
+                         "oldkeys": {                                                                                                                                                                                            +
+                                 "keynames": ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p"],                                                                                                   +
+                                 "keytypes": ["int2", "int2", "int4", "int8", "numeric", "float4", "float8", "bpchar", "varchar", "text", "varbit", "timestamp", "date", "bool", "json", "tsvector"],                            +
+                                 "keyvalues": [2, 1, 2, 3, 3.540, 876.563, 1.23, "teste     ", "testando", "um texto longo", "001110010101010", "Sat Nov 02 17:30:52 2013", "02-04-2013", true, "{ \"a\": 123 }", "'Old' 'Parr'"]+
+                         }                                                                                                                                                                                                       +
+                 }
+         ]                                                                                                                                                                                                                       +
+ }
+(12 rows)
+
 SELECT 'stop' FROM pg_drop_replication_slot('regression_slot');
  ?column? 
 ----------

--- a/expected/delete3.out
+++ b/expected/delete3.out
@@ -195,7 +195,7 @@ ALTER TABLE table_without_pk REPLICA IDENTITY DEFAULT;
 ALTER TABLE table_with_unique REPLICA IDENTITY FULL;
 DELETE FROM table_with_unique WHERE b = 1;
 ALTER TABLE table_with_unique REPLICA IDENTITY DEFAULT;
-SELECT data FROM pg_logical_slot_get_changes('regression_slot', NULL, NULL, 'include-xids', '0', 'pretty-print', '1', 'skip-empty-xacts', '1');
+SELECT data FROM pg_logical_slot_get_changes('regression_slot', NULL, NULL, 'include-xids', '0', 'pretty-print', '1', 'include-empty-xacts', '0');
                                                                                                                data                                                                                                               
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  {                                                                                                                                                                                                                               +

--- a/sql/delete1.sql
+++ b/sql/delete1.sql
@@ -70,6 +70,9 @@ UNIQUE(g, n)
 INSERT INTO table_with_pk (b, c, d, e, f, g, h, i, j, k, l, m, n, o, p) VALUES(1, 2, 3, 3.54, 876.563452345, 1.23, 'teste', 'testando', 'um texto longo', B'001110010101010', '2013-11-02 17:30:52', '2013-02-04', true, '{ "a": 123 }', 'Old Old Parr'::tsvector);
 INSERT INTO table_without_pk (b, c, d, e, f, g, h, i, j, k, l, m, n, o, p) VALUES(1, 2, 3, 3.54, 876.563452345, 1.23, 'teste', 'testando', 'um texto longo', B'001110010101010', '2013-11-02 17:30:52', '2013-02-04', true, '{ "a": 123 }', 'Old Old Parr'::tsvector);
 INSERT INTO table_with_unique (b, c, d, e, f, g, h, i, j, k, l, m, n, o, p) VALUES(1, 2, 3, 3.54, 876.563452345, 1.23, 'teste', 'testando', 'um texto longo', B'001110010101010', '2013-11-02 17:30:52', '2013-02-04', true, '{ "a": 123 }', 'Old Old Parr'::tsvector);
+INSERT INTO table_with_pk (b, c, d, e, f, g, h, i, j, k, l, m, n, o, p) VALUES(2, 2, 3, 3.54, 876.563452345, 1.23, 'teste', 'testando', 'um texto longo', B'001110010101010', '2013-11-02 17:30:52', '2013-02-04', false, '{ "a": 123 }', 'Old Old Parr'::tsvector);
+INSERT INTO table_without_pk (b, c, d, e, f, g, h, i, j, k, l, m, n, o, p) VALUES(2, 2, 3, 3.54, 876.563452345, 1.23, 'teste', 'testando', 'um texto longo', B'001110010101010', '2013-11-02 17:30:52', '2013-02-04', false, '{ "a": 123 }', 'Old Old Parr'::tsvector);
+INSERT INTO table_with_unique (b, c, d, e, f, g, h, i, j, k, l, m, n, o, p) VALUES(2, 2, 3, 3.54, 876.563452345, 1.23, 'teste', 'testando', 'um texto longo', B'001110010101010', '2013-11-02 17:30:52', '2013-02-04', false, '{ "a": 123 }', 'Old Old Parr'::tsvector);
 
 SELECT 'init' FROM pg_create_logical_replication_slot('regression_slot', 'wal2json');
 
@@ -83,4 +86,13 @@ DELETE FROM table_with_pk WHERE b = 1;
 DELETE FROM table_with_unique WHERE b = 1;
 
 SELECT data FROM pg_logical_slot_get_changes('regression_slot', NULL, NULL, 'include-xids', '0', 'pretty-print', '1');
+
+-- Again, hiding empty xacts
+DELETE FROM table_without_pk WHERE b = 2;
+DELETE FROM table_with_pk WHERE b = 2;
+DELETE FROM table_with_unique WHERE b = 2;
+
+SELECT data FROM pg_logical_slot_get_changes('regression_slot', NULL, NULL, 'include-xids', '0', 'pretty-print', '1', 'skip-empty-xacts', '1');
+
+
 SELECT 'stop' FROM pg_drop_replication_slot('regression_slot');

--- a/sql/delete1.sql
+++ b/sql/delete1.sql
@@ -92,7 +92,7 @@ DELETE FROM table_without_pk WHERE b = 2;
 DELETE FROM table_with_pk WHERE b = 2;
 DELETE FROM table_with_unique WHERE b = 2;
 
-SELECT data FROM pg_logical_slot_get_changes('regression_slot', NULL, NULL, 'include-xids', '0', 'pretty-print', '1', 'skip-empty-xacts', '1');
+SELECT data FROM pg_logical_slot_get_changes('regression_slot', NULL, NULL, 'include-xids', '0', 'pretty-print', '1', 'include-empty-xacts', '0');
 
 
 SELECT 'stop' FROM pg_drop_replication_slot('regression_slot');

--- a/sql/delete2.sql
+++ b/sql/delete2.sql
@@ -101,6 +101,6 @@ ALTER TABLE table_with_unique REPLICA IDENTITY NOTHING;
 DELETE FROM table_with_unique WHERE b = 1;
 ALTER TABLE table_with_unique REPLICA IDENTITY DEFAULT;
 
-SELECT data FROM pg_logical_slot_get_changes('regression_slot', NULL, NULL, 'include-xids', '0', 'pretty-print', '1', 'skip-empty-xacts', '1');
+SELECT data FROM pg_logical_slot_get_changes('regression_slot', NULL, NULL, 'include-xids', '0', 'pretty-print', '1', 'include-empty-xacts', '0');
 
 SELECT 'stop' FROM pg_drop_replication_slot('regression_slot');

--- a/sql/delete2.sql
+++ b/sql/delete2.sql
@@ -87,4 +87,20 @@ DELETE FROM table_with_unique WHERE b = 1;
 ALTER TABLE table_with_unique REPLICA IDENTITY DEFAULT;
 
 SELECT data FROM pg_logical_slot_get_changes('regression_slot', NULL, NULL, 'include-xids', '0', 'pretty-print', '1');
+
+-- Test skipping empty xacts
+ALTER TABLE table_with_pk REPLICA IDENTITY NOTHING;
+DELETE FROM table_with_pk WHERE b = 1;
+ALTER TABLE table_with_pk REPLICA IDENTITY DEFAULT;
+
+ALTER TABLE table_without_pk REPLICA IDENTITY NOTHING;
+DELETE FROM table_without_pk WHERE b = 1;
+ALTER TABLE table_without_pk REPLICA IDENTITY DEFAULT;
+
+ALTER TABLE table_with_unique REPLICA IDENTITY NOTHING;
+DELETE FROM table_with_unique WHERE b = 1;
+ALTER TABLE table_with_unique REPLICA IDENTITY DEFAULT;
+
+SELECT data FROM pg_logical_slot_get_changes('regression_slot', NULL, NULL, 'include-xids', '0', 'pretty-print', '1', 'skip-empty-xacts', '1');
+
 SELECT 'stop' FROM pg_drop_replication_slot('regression_slot');

--- a/sql/delete3.sql
+++ b/sql/delete3.sql
@@ -116,6 +116,6 @@ ALTER TABLE table_with_unique REPLICA IDENTITY FULL;
 DELETE FROM table_with_unique WHERE b = 1;
 ALTER TABLE table_with_unique REPLICA IDENTITY DEFAULT;
 
-SELECT data FROM pg_logical_slot_get_changes('regression_slot', NULL, NULL, 'include-xids', '0', 'pretty-print', '1', 'skip-empty-xacts', '1');
+SELECT data FROM pg_logical_slot_get_changes('regression_slot', NULL, NULL, 'include-xids', '0', 'pretty-print', '1', 'include-empty-xacts', '0');
 
 SELECT 'stop' FROM pg_drop_replication_slot('regression_slot');

--- a/sql/delete3.sql
+++ b/sql/delete3.sql
@@ -89,4 +89,33 @@ DELETE FROM table_with_unique WHERE b = 1;
 ALTER TABLE table_with_unique REPLICA IDENTITY DEFAULT;
 
 SELECT data FROM pg_logical_slot_get_changes('regression_slot', NULL, NULL, 'include-xids', '0', 'pretty-print', '1');
+
+
+-- Test skipping empty xacts
+
+SELECT 'stop' FROM pg_drop_replication_slot('regression_slot');
+
+INSERT INTO table_with_pk (b, c, d, e, f, g, h, i, j, k, l, m, n, o, p) VALUES(1, 2, 3, 3.54, 876.563452345, 1.23, 'teste', 'testando', 'um texto longo', B'001110010101010', '2013-11-02 17:30:52', '2013-02-04', true, '{ "a": 123 }', 'Old Old Parr'::tsvector);
+INSERT INTO table_with_pk (b, c, d, e, f, g, h, i, j, k, l, m, n, o, p) VALUES(4, 5, 6, 3.54, 876.563452345, 1.23, 'teste', 'testando', 'um texto longo', B'001110010101010', '2013-11-02 17:30:52', '2013-02-04', true, '{ "a": 123 }', 'Old Old Parr'::tsvector);
+INSERT INTO table_without_pk (b, c, d, e, f, g, h, i, j, k, l, m, n, o, p) VALUES(1, 2, 3, 3.54, 876.563452345, 1.23, 'teste', 'testando', 'um texto longo', B'001110010101010', '2013-11-02 17:30:52', '2013-02-04', true, '{ "a": 123 }', 'Old Old Parr'::tsvector);
+INSERT INTO table_with_unique (b, c, d, e, f, g, h, i, j, k, l, m, n, o, p) VALUES(1, 2, 3, 3.54, 876.563452345, 1.23, 'teste', 'testando', 'um texto longo', B'001110010101010', '2013-11-02 17:30:52', '2013-02-04', true, '{ "a": 123 }', 'Old Old Parr'::tsvector);
+
+SELECT 'init' FROM pg_create_logical_replication_slot('regression_slot', 'wal2json');
+
+-- DELETE: REPLICA IDENTITY FULL
+ALTER TABLE table_with_pk REPLICA IDENTITY FULL;
+DELETE FROM table_with_pk WHERE b = 1;
+DELETE FROM table_with_pk WHERE n = true;
+ALTER TABLE table_with_pk REPLICA IDENTITY DEFAULT;
+
+ALTER TABLE table_without_pk REPLICA IDENTITY FULL;
+DELETE FROM table_without_pk WHERE b = 1;
+ALTER TABLE table_without_pk REPLICA IDENTITY DEFAULT;
+
+ALTER TABLE table_with_unique REPLICA IDENTITY FULL;
+DELETE FROM table_with_unique WHERE b = 1;
+ALTER TABLE table_with_unique REPLICA IDENTITY DEFAULT;
+
+SELECT data FROM pg_logical_slot_get_changes('regression_slot', NULL, NULL, 'include-xids', '0', 'pretty-print', '1', 'skip-empty-xacts', '1');
+
 SELECT 'stop' FROM pg_drop_replication_slot('regression_slot');

--- a/wal2json.c
+++ b/wal2json.c
@@ -218,7 +218,10 @@ pg_decode_startup(LogicalDecodingContext *ctx, OutputPluginOptions *opt, bool is
 		{
 
 			if (elem->arg == NULL)
+			{
+				elog(LOG, "skip-empty-xacts argument is null");
 				data->skip_empty_xacts = true;
+			}
 			else if (!parse_bool(strVal(elem->arg), &data->skip_empty_xacts))
 				ereport(ERROR,
 						(errcode(ERRCODE_INVALID_PARAMETER_VALUE),

--- a/wal2json.c
+++ b/wal2json.c
@@ -268,7 +268,7 @@ output_begin(LogicalDecodingContext *ctx, JsonDecodingData *data,
 		ReorderBufferTXN *txn, bool last_write)
 {
 	/* Transaction starts */
-	OutputPluginPrepareWrite(ctx, true);
+	OutputPluginPrepareWrite(ctx, last_write);
 
 	if (data->pretty_print)
 		appendStringInfoString(ctx->out, "{\n");

--- a/wal2json.c
+++ b/wal2json.c
@@ -70,6 +70,9 @@ static void pg_decode_change(LogicalDecodingContext *ctx,
 				 ReorderBufferTXN *txn, Relation rel,
 				 ReorderBufferChange *change);
 
+static void output_begin(LogicalDecodingContext *ctx, JsonDecodingData *data,
+		ReorderBufferTXN *txn, bool last_write);
+
 void
 _PG_init(void)
 {
@@ -249,9 +252,6 @@ pg_decode_shutdown(LogicalDecodingContext *ctx)
 
 
 /* BEGIN callback */
-static void output_begin(LogicalDecodingContext *ctx, JsonDecodingData *data,
-		ReorderBufferTXN *txn, bool last_write);
-
 void
 pg_decode_begin_txn(LogicalDecodingContext *ctx, ReorderBufferTXN *txn)
 {


### PR DESCRIPTION
This merge request adds the option to skip empty transactions. The first commit is the subject of MR #11: it's included here because without that running tests is impossible. If that's merged before I can rebase this branch.