### PR TITLE
Output logical messages sent via pg_logical_emit_message

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ env:
     - PG_VERSION=9.4
     - PG_VERSION=9.5
     - PG_VERSION=9.6
+    - PG_VERSION=10
 
 language: c
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,25 @@
+sudo: required
+
+branches:
+  only:
+    - master
+    - pg_logical_emit_message
+    - travis-builds
+
+env:
+  matrix:
+    - PG_VERSION=9.4
+    - PG_VERSION=9.5
+    - PG_VERSION=9.6
+
+language: c
+
+services:
+  - docker
+
+before_install:
+  - docker pull dpirotte/postgres-dev:jessie
+
+script:
+  - docker run --rm -v $PWD:/build -w /build -it -e PG_CONFIG=/usr/lib/postgresql/$PG_VERSION/bin/pg_config dpirotte/postgres-dev:jessie bash -c "pg_ctlcluster $PG_VERSION main start && make clean all install installcheck"
+

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 MODULES = wal2json
 
 REGRESS = cmdline insert1 update1 update2 update3 update4 delete1 delete2 \
-		  delete3 delete4 savepoint specialvalue toast bytea
+		  delete3 delete4 savepoint specialvalue toast bytea message
 
 PG_CONFIG = pg_config
 PGXS := $(shell $(PG_CONFIG) --pgxs)

--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,12 @@ MODULES = wal2json
 REGRESS = cmdline insert1 update1 update2 update3 update4 delete1 delete2 \
 		  delete3 delete4 savepoint specialvalue toast bytea
 
-PG_VERSION ?= 9.6
-PG_CONFIG = /usr/lib/postgresql/${PG_VERSION}/bin/pg_config
+PG_CONFIG ?= pg_config
 
-ifeq ($(PG_VERSION),9.6)
+PG_VERSION := $(shell $(PG_CONFIG) --version | awk '{print $$2}')
+INTVERSION := $(shell echo $$(($$(echo $(PG_VERSION) | sed 's/\([[:digit:]]\{1,\}\)\.\([[:digit:]]\{1,\}\).*/\1*100+\2/'))))
+
+ifeq ($(shell echo $$(($(INTVERSION) >= 906))),1)
 	REGRESS += message
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,15 @@
 MODULES = wal2json
 
 REGRESS = cmdline insert1 update1 update2 update3 update4 delete1 delete2 \
-		  delete3 delete4 savepoint specialvalue toast bytea message
+		  delete3 delete4 savepoint specialvalue toast bytea
 
-PG_CONFIG = pg_config
+PG_VERSION ?= 9.6
+PG_CONFIG = /usr/lib/postgresql/${PG_VERSION}/bin/pg_config
+
+ifeq ($(PG_VERSION),9.6)
+	REGRESS += message
+endif
+
 PGXS := $(shell $(PG_CONFIG) --pgxs)
 include $(PGXS)
 

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ REGRESS = cmdline insert1 update1 update2 update3 update4 delete1 delete2 \
 
 PG_CONFIG ?= pg_config
 
-PG_VERSION := $(shell $(PG_CONFIG) --version | awk '{print $$2}')
+PG_VERSION := $(shell $(PG_CONFIG) --version | awk '{print $$2}' | sed 's/[[:alpha:]].*$$/.0/')
 INTVERSION := $(shell echo $$(($$(echo $(PG_VERSION) | sed 's/\([[:digit:]]\{1,\}\)\.\([[:digit:]]\{1,\}\).*/\1*100+\2/'))))
 
 ifeq ($(shell echo $$(($(INTVERSION) >= 906))),1)

--- a/expected/message.out
+++ b/expected/message.out
@@ -171,6 +171,25 @@ SELECT data FROM pg_logical_slot_get_changes('regression_slot', NULL, NULL);
  {"change":[{"kind":"insert","schema":"public","table":"message_table","columnnames":["a","b"],"columntypes":["int2","int2"],"columnvalues":[4,1]},{"kind":"insert","schema":"public","table":"message_table","columnnames":["a","b"],"columntypes":["int2","int2"],"columnvalues":[5,2]}]}
 (2 rows)
 
+-- Standalone non-transactional messages
+SELECT 'emit' FROM pg_logical_emit_message(false, 'non-transactional prefix', 'standalone non-transactional message');
+ ?column? 
+----------
+ emit
+(1 row)
+
+SELECT pg_sleep(0.5); -- need a slight wait for the message to make it to decoding
+ pg_sleep 
+----------
+ 
+(1 row)
+
+SELECT data FROM pg_logical_slot_get_changes('regression_slot', NULL, NULL);
+                                                                    data                                                                    
+--------------------------------------------------------------------------------------------------------------------------------------------
+ {"change":[{"kind":"message","transactional":false,"prefix":"non-transactional prefix","content":"standalone non-transactional message"}]}
+(1 row)
+
 -- Bytea
 SELECT 'emit' FROM pg_logical_emit_message(true, 'bytea prefix', decode('DEADBEEF', 'hex'));
  ?column? 

--- a/expected/message.out
+++ b/expected/message.out
@@ -16,9 +16,9 @@ SELECT 'emit' FROM pg_logical_emit_message(true, 'foo', 'bar');
 (1 row)
 
 SELECT data FROM pg_logical_slot_get_changes('regression_slot', NULL, NULL);
-                                        data                                        
-------------------------------------------------------------------------------------
- {"change":[{"kind":"message","transactional":"1","prefix":"foo","content":"bar"}]}
+                                        data                                         
+-------------------------------------------------------------------------------------
+ {"change":[{"kind":"message","transactional":true,"prefix":"foo","content":"bar"}]}
 (1 row)
 
 -- Two messages
@@ -37,9 +37,9 @@ SELECT 'emit' FROM pg_logical_emit_message(true, 'foo', 'bar');
 
 COMMIT;
 SELECT data FROM pg_logical_slot_get_changes('regression_slot', NULL, NULL);
-                                                                           data                                                                           
-----------------------------------------------------------------------------------------------------------------------------------------------------------
- {"change":[{"kind":"message","transactional":"1","prefix":"foo","content":"bar"},{"kind":"message","transactional":"1","prefix":"foo","content":"bar"}]}
+                                                                            data                                                                            
+------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {"change":[{"kind":"message","transactional":true,"prefix":"foo","content":"bar"},{"kind":"message","transactional":true,"prefix":"foo","content":"bar"}]}
 (1 row)
 
 -- Message sandwiched by changes
@@ -54,9 +54,9 @@ SELECT 'emit' FROM pg_logical_emit_message(true, 'foo', 'bar');
 INSERT INTO message_table (b) VALUES (2);
 COMMIT;
 SELECT data FROM pg_logical_slot_get_changes('regression_slot', NULL, NULL);
-                                                                                                                                                                               data                                                                                                                                                                               
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- {"change":[{"kind":"insert","schema":"public","table":"message_table","columnnames":["a","b"],"columntypes":["int2","int2"],"columnvalues":[1,1]},{"kind":"message","transactional":"1","prefix":"foo","content":"bar"},{"kind":"insert","schema":"public","table":"message_table","columnnames":["a","b"],"columntypes":["int2","int2"],"columnvalues":[2,2]}]}
+                                                                                                                                                                               data                                                                                                                                                                                
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {"change":[{"kind":"insert","schema":"public","table":"message_table","columnnames":["a","b"],"columntypes":["int2","int2"],"columnvalues":[1,1]},{"kind":"message","transactional":true,"prefix":"foo","content":"bar"},{"kind":"insert","schema":"public","table":"message_table","columnnames":["a","b"],"columntypes":["int2","int2"],"columnvalues":[2,2]}]}
 (1 row)
 
 -- Changes sandwiched by messages
@@ -76,9 +76,9 @@ SELECT 'emit' FROM pg_logical_emit_message(true, 'after', 'after');
 
 COMMIT;
 SELECT data FROM pg_logical_slot_get_changes('regression_slot', NULL, NULL);
-                                                                                                                                                   data                                                                                                                                                    
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- {"change":[{"kind":"message","transactional":"1","prefix":"before","content":"before"},{"kind":"insert","schema":"public","table":"message_table","columnnames":["a","b"],"columntypes":["int2","int2"],"columnvalues":[3,3]},{"kind":"message","transactional":"1","prefix":"after","content":"after"}]}
+                                                                                                                                                    data                                                                                                                                                     
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {"change":[{"kind":"message","transactional":true,"prefix":"before","content":"before"},{"kind":"insert","schema":"public","table":"message_table","columnnames":["a","b"],"columntypes":["int2","int2"],"columnvalues":[3,3]},{"kind":"message","transactional":true,"prefix":"after","content":"after"}]}
 (1 row)
 
 -- Changes with newlines and quotes
@@ -90,9 +90,9 @@ SELECT 'emit' FROM pg_logical_emit_message(true, 'funky prefix', 'well " " " "" 
 (1 row)
 
 SELECT data FROM pg_logical_slot_get_changes('regression_slot', NULL, NULL);
-                                                                 data                                                                  
----------------------------------------------------------------------------------------------------------------------------------------
- {"change":[{"kind":"message","transactional":"1","prefix":"funky prefix","content":"well \" \" \" \"\" \"\" ' ' \n' ' ] [ { } foo"}]}
+                                                                  data                                                                  
+----------------------------------------------------------------------------------------------------------------------------------------
+ {"change":[{"kind":"message","transactional":true,"prefix":"funky prefix","content":"well \" \" \" \"\" \"\" ' ' \n' ' ] [ { } foo"}]}
 (1 row)
 
 -- Pretty
@@ -117,13 +117,13 @@ SELECT data FROM pg_logical_slot_get_changes('regression_slot', NULL, NULL, 'pre
          "change": [                               +
                  {                                 +
                          "kind": "message",        +
-                         "transactional": "1",     +
+                         "transactional": true,    +
                          "prefix": "pretty prefix",+
                          "content": "pretty1"      +
                  }                                 +
                  ,{                                +
                          "kind": "message",        +
-                         "transactional": "1",     +
+                         "transactional": true,    +
                          "prefix": "pretty prefix",+
                          "content": "pretty2"      +
                  }                                 +
@@ -145,7 +145,7 @@ SELECT data FROM pg_logical_slot_get_changes('regression_slot', NULL, NULL, 'pre
          "change": [                                              +
                  {                                                +
                          "kind": "message",                       +
-                         "transactional": "1",                    +
+                         "transactional": true,                   +
                          "prefix": "a pretty prefix that is long",+
                          "content": "a"                           +
                  }                                                +
@@ -167,7 +167,7 @@ COMMIT;
 SELECT data FROM pg_logical_slot_get_changes('regression_slot', NULL, NULL);
                                                                                                                                             data                                                                                                                                            
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- {"change":[{"kind":"message","transactional":"0","prefix":"non-transactional prefix","content":"non-transactional message"}]}
+ {"change":[{"kind":"message","transactional":false,"prefix":"non-transactional prefix","content":"non-transactional message"}]}
  {"change":[{"kind":"insert","schema":"public","table":"message_table","columnnames":["a","b"],"columntypes":["int2","int2"],"columnvalues":[4,1]},{"kind":"insert","schema":"public","table":"message_table","columnnames":["a","b"],"columntypes":["int2","int2"],"columnvalues":[5,2]}]}
 (2 rows)
 

--- a/expected/message.out
+++ b/expected/message.out
@@ -1,0 +1,139 @@
+\set VERBOSITY terse
+-- predictability
+SET synchronous_commit = on;
+CREATE TABLE message_table (a smallserial, b smallint);
+SELECT 'init' FROM pg_create_logical_replication_slot('regression_slot', 'wal2json');
+ ?column? 
+----------
+ init
+(1 row)
+
+-- One message
+SELECT 'emit' FROM pg_logical_emit_message(true, 'foo', 'bar');
+ ?column? 
+----------
+ emit
+(1 row)
+
+SELECT data FROM pg_logical_slot_get_changes('regression_slot', NULL, NULL);
+                                        data                                        
+------------------------------------------------------------------------------------
+ {"change":[{"kind":"message","transactional":"1","prefix":"foo","content":"bar"}]}
+(1 row)
+
+-- Two messages
+BEGIN;
+SELECT 'emit' FROM pg_logical_emit_message(true, 'foo', 'bar');
+ ?column? 
+----------
+ emit
+(1 row)
+
+SELECT 'emit' FROM pg_logical_emit_message(true, 'foo', 'bar');
+ ?column? 
+----------
+ emit
+(1 row)
+
+COMMIT;
+SELECT data FROM pg_logical_slot_get_changes('regression_slot', NULL, NULL);
+                                                                           data                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------
+ {"change":[{"kind":"message","transactional":"1","prefix":"foo","content":"bar"},{"kind":"message","transactional":"1","prefix":"foo","content":"bar"}]}
+(1 row)
+
+-- Message sandwiched by changes
+BEGIN;
+INSERT INTO message_table (b) VALUES (1);
+SELECT 'emit' FROM pg_logical_emit_message(true, 'foo', 'bar');
+ ?column? 
+----------
+ emit
+(1 row)
+
+INSERT INTO message_table (b) VALUES (2);
+COMMIT;
+SELECT data FROM pg_logical_slot_get_changes('regression_slot', NULL, NULL);
+                                                                                                                                                                               data                                                                                                                                                                               
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {"change":[{"kind":"insert","schema":"public","table":"message_table","columnnames":["a","b"],"columntypes":["int2","int2"],"columnvalues":[1,1]},{"kind":"message","transactional":"1","prefix":"foo","content":"bar"},{"kind":"insert","schema":"public","table":"message_table","columnnames":["a","b"],"columntypes":["int2","int2"],"columnvalues":[2,2]}]}
+(1 row)
+
+-- Changes sandwiched by messages
+BEGIN;
+SELECT 'emit' FROM pg_logical_emit_message(true, 'before', 'before');
+ ?column? 
+----------
+ emit
+(1 row)
+
+INSERT INTO message_table (b) VALUES (3);
+SELECT 'emit' FROM pg_logical_emit_message(true, 'after', 'after');
+ ?column? 
+----------
+ emit
+(1 row)
+
+COMMIT;
+SELECT data FROM pg_logical_slot_get_changes('regression_slot', NULL, NULL);
+                                                                                                                                                   data                                                                                                                                                    
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {"change":[{"kind":"message","transactional":"1","prefix":"before","content":"before"},{"kind":"insert","schema":"public","table":"message_table","columnnames":["a","b"],"columntypes":["int2","int2"],"columnvalues":[3,3]},{"kind":"message","transactional":"1","prefix":"after","content":"after"}]}
+(1 row)
+
+-- Changes with newlines and quotes
+SELECT 'emit' FROM pg_logical_emit_message(true, 'funky prefix', 'well " " " "" "" '' '' 
+'' '' ] [ { } foo');
+ ?column? 
+----------
+ emit
+(1 row)
+
+SELECT data FROM pg_logical_slot_get_changes('regression_slot', NULL, NULL);
+                                                                 data                                                                  
+---------------------------------------------------------------------------------------------------------------------------------------
+ {"change":[{"kind":"message","transactional":"1","prefix":"funky prefix","content":"well \" \" \" \"\" \"\" ' ' \n' ' ] [ { } foo"}]}
+(1 row)
+
+-- Pretty
+BEGIN;
+SELECT 'emit' FROM pg_logical_emit_message(true, 'pretty prefix', 'pretty1');
+ ?column? 
+----------
+ emit
+(1 row)
+
+SELECT 'emit' FROM pg_logical_emit_message(true, 'pretty prefix', 'pretty2');
+ ?column? 
+----------
+ emit
+(1 row)
+
+COMMIT;
+SELECT data FROM pg_logical_slot_get_changes('regression_slot', NULL, NULL, 'pretty-print', '1');
+                        data                        
+----------------------------------------------------
+ {                                                 +
+         "change": [                               +
+                 {                                 +
+                         "kind": "message",        +
+                         "transactional": "1",     +
+                         "prefix": "pretty prefix",+
+                         "content": "pretty1"      +
+                 }                                 +
+                 ,{                                +
+                         "kind": "message",        +
+                         "transactional": "1",     +
+                         "prefix": "pretty prefix",+
+                         "content": "pretty2"      +
+                 }                                 +
+         ]                                         +
+ }
+(1 row)
+
+SELECT 'stop' FROM pg_drop_replication_slot('regression_slot');
+ ?column? 
+----------
+ stop
+(1 row)
+

--- a/expected/message.out
+++ b/expected/message.out
@@ -131,6 +131,28 @@ SELECT data FROM pg_logical_slot_get_changes('regression_slot', NULL, NULL, 'pre
  }
 (1 row)
 
+-- Small message renders correct size
+SELECT 'emit' FROM pg_logical_emit_message(true, 'a pretty prefix that is long', 'a');
+ ?column? 
+----------
+ emit
+(1 row)
+
+SELECT data FROM pg_logical_slot_get_changes('regression_slot', NULL, NULL, 'pretty-print', '1');
+                               data                                
+-------------------------------------------------------------------
+ {                                                                +
+         "change": [                                              +
+                 {                                                +
+                         "kind": "message",                       +
+                         "transactional": "1",                    +
+                         "prefix": "a pretty prefix that is long",+
+                         "content": "a"                           +
+                 }                                                +
+         ]                                                        +
+ }
+(1 row)
+
 SELECT 'stop' FROM pg_drop_replication_slot('regression_slot');
  ?column? 
 ----------

--- a/expected/message.out
+++ b/expected/message.out
@@ -171,6 +171,19 @@ SELECT data FROM pg_logical_slot_get_changes('regression_slot', NULL, NULL);
  {"change":[{"kind":"insert","schema":"public","table":"message_table","columnnames":["a","b"],"columntypes":["int2","int2"],"columnvalues":[4,1]},{"kind":"insert","schema":"public","table":"message_table","columnnames":["a","b"],"columntypes":["int2","int2"],"columnvalues":[5,2]}]}
 (2 rows)
 
+-- Bytea
+SELECT 'emit' FROM pg_logical_emit_message(true, 'bytea prefix', decode('DEADBEEF', 'hex'));
+ ?column? 
+----------
+ emit
+(1 row)
+
+SELECT data FROM pg_logical_slot_get_changes('regression_slot', NULL, NULL);
+                                           data                                            
+-------------------------------------------------------------------------------------------
+ {"change":[{"kind":"message","transactional":true,"prefix":"bytea prefix","content":"ޭ"}]}
+(1 row)
+
 SELECT 'stop' FROM pg_drop_replication_slot('regression_slot');
  ?column? 
 ----------

--- a/expected/message.out
+++ b/expected/message.out
@@ -153,6 +153,24 @@ SELECT data FROM pg_logical_slot_get_changes('regression_slot', NULL, NULL, 'pre
  }
 (1 row)
 
+-- Non-transactional messages
+BEGIN;
+INSERT INTO message_table (b) VALUES (1);
+SELECT 'emit' FROM pg_logical_emit_message(false, 'non-transactional prefix', 'non-transactional message');
+ ?column? 
+----------
+ emit
+(1 row)
+
+INSERT INTO message_table (b) VALUES (2);
+COMMIT;
+SELECT data FROM pg_logical_slot_get_changes('regression_slot', NULL, NULL);
+                                                                                                                                            data                                                                                                                                            
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {"change":[{"kind":"message","transactional":"0","prefix":"non-transactional prefix","content":"non-transactional message"}]}
+ {"change":[{"kind":"insert","schema":"public","table":"message_table","columnnames":["a","b"],"columntypes":["int2","int2"],"columnvalues":[4,1]},{"kind":"insert","schema":"public","table":"message_table","columnnames":["a","b"],"columntypes":["int2","int2"],"columnvalues":[5,2]}]}
+(2 rows)
+
 SELECT 'stop' FROM pg_drop_replication_slot('regression_slot');
  ?column? 
 ----------

--- a/sql/message.sql
+++ b/sql/message.sql
@@ -58,6 +58,11 @@ INSERT INTO message_table (b) VALUES (2);
 COMMIT;
 SELECT data FROM pg_logical_slot_get_changes('regression_slot', NULL, NULL);
 
+-- Standalone non-transactional messages
+SELECT 'emit' FROM pg_logical_emit_message(false, 'non-transactional prefix', 'standalone non-transactional message');
+SELECT pg_sleep(0.5); -- need a slight wait for the message to make it to decoding
+SELECT data FROM pg_logical_slot_get_changes('regression_slot', NULL, NULL);
+
 -- Bytea
 SELECT 'emit' FROM pg_logical_emit_message(true, 'bytea prefix', decode('DEADBEEF', 'hex'));
 SELECT data FROM pg_logical_slot_get_changes('regression_slot', NULL, NULL);

--- a/sql/message.sql
+++ b/sql/message.sql
@@ -1,0 +1,49 @@
+\set VERBOSITY terse
+
+-- predictability
+SET synchronous_commit = on;
+
+CREATE TABLE message_table (a smallserial, b smallint);
+
+SELECT 'init' FROM pg_create_logical_replication_slot('regression_slot', 'wal2json');
+
+-- One message
+SELECT 'emit' FROM pg_logical_emit_message(true, 'foo', 'bar');
+SELECT data FROM pg_logical_slot_get_changes('regression_slot', NULL, NULL);
+
+-- Two messages
+BEGIN;
+SELECT 'emit' FROM pg_logical_emit_message(true, 'foo', 'bar');
+SELECT 'emit' FROM pg_logical_emit_message(true, 'foo', 'bar');
+COMMIT;
+SELECT data FROM pg_logical_slot_get_changes('regression_slot', NULL, NULL);
+
+-- Message sandwiched by changes
+BEGIN;
+INSERT INTO message_table (b) VALUES (1);
+SELECT 'emit' FROM pg_logical_emit_message(true, 'foo', 'bar');
+INSERT INTO message_table (b) VALUES (2);
+COMMIT;
+SELECT data FROM pg_logical_slot_get_changes('regression_slot', NULL, NULL);
+
+-- Changes sandwiched by messages
+BEGIN;
+SELECT 'emit' FROM pg_logical_emit_message(true, 'before', 'before');
+INSERT INTO message_table (b) VALUES (3);
+SELECT 'emit' FROM pg_logical_emit_message(true, 'after', 'after');
+COMMIT;
+SELECT data FROM pg_logical_slot_get_changes('regression_slot', NULL, NULL);
+
+-- Changes with newlines and quotes
+SELECT 'emit' FROM pg_logical_emit_message(true, 'funky prefix', 'well " " " "" "" '' '' 
+'' '' ] [ { } foo');
+SELECT data FROM pg_logical_slot_get_changes('regression_slot', NULL, NULL);
+
+-- Pretty
+BEGIN;
+SELECT 'emit' FROM pg_logical_emit_message(true, 'pretty prefix', 'pretty1');
+SELECT 'emit' FROM pg_logical_emit_message(true, 'pretty prefix', 'pretty2');
+COMMIT;
+SELECT data FROM pg_logical_slot_get_changes('regression_slot', NULL, NULL, 'pretty-print', '1');
+
+SELECT 'stop' FROM pg_drop_replication_slot('regression_slot');

--- a/sql/message.sql
+++ b/sql/message.sql
@@ -46,4 +46,8 @@ SELECT 'emit' FROM pg_logical_emit_message(true, 'pretty prefix', 'pretty2');
 COMMIT;
 SELECT data FROM pg_logical_slot_get_changes('regression_slot', NULL, NULL, 'pretty-print', '1');
 
+-- Small message renders correct size
+SELECT 'emit' FROM pg_logical_emit_message(true, 'a pretty prefix that is long', 'a');
+SELECT data FROM pg_logical_slot_get_changes('regression_slot', NULL, NULL, 'pretty-print', '1');
+
 SELECT 'stop' FROM pg_drop_replication_slot('regression_slot');

--- a/sql/message.sql
+++ b/sql/message.sql
@@ -50,4 +50,12 @@ SELECT data FROM pg_logical_slot_get_changes('regression_slot', NULL, NULL, 'pre
 SELECT 'emit' FROM pg_logical_emit_message(true, 'a pretty prefix that is long', 'a');
 SELECT data FROM pg_logical_slot_get_changes('regression_slot', NULL, NULL, 'pretty-print', '1');
 
+-- Non-transactional messages
+BEGIN;
+INSERT INTO message_table (b) VALUES (1);
+SELECT 'emit' FROM pg_logical_emit_message(false, 'non-transactional prefix', 'non-transactional message');
+INSERT INTO message_table (b) VALUES (2);
+COMMIT;
+SELECT data FROM pg_logical_slot_get_changes('regression_slot', NULL, NULL);
+
 SELECT 'stop' FROM pg_drop_replication_slot('regression_slot');

--- a/sql/message.sql
+++ b/sql/message.sql
@@ -58,4 +58,8 @@ INSERT INTO message_table (b) VALUES (2);
 COMMIT;
 SELECT data FROM pg_logical_slot_get_changes('regression_slot', NULL, NULL);
 
+-- Bytea
+SELECT 'emit' FROM pg_logical_emit_message(true, 'bytea prefix', decode('DEADBEEF', 'hex'));
+SELECT data FROM pg_logical_slot_get_changes('regression_slot', NULL, NULL);
+
 SELECT 'stop' FROM pg_drop_replication_slot('regression_slot');

--- a/wal2json.c
+++ b/wal2json.c
@@ -888,6 +888,7 @@ pg_decode_message(LogicalDecodingContext *ctx,
 	JsonDecodingData *data;
 	MemoryContext old;
 	StringInfoData message_buffer;
+	StringInfoData prefix_buffer;
 
 	/*
 	 * Punt on handling non-transactional logical messages as they don't really
@@ -902,6 +903,7 @@ pg_decode_message(LogicalDecodingContext *ctx,
 	data = ctx->output_plugin_private;
 	old = MemoryContextSwitchTo(data->context);
 	initStringInfo(&message_buffer);
+	initStringInfo(&prefix_buffer);
 
 	/* Message counter */
 	data->nr_changes++;
@@ -941,7 +943,8 @@ pg_decode_message(LogicalDecodingContext *ctx,
 		appendStringInfoString(ctx->out, "\"prefix\":");
 	}
 
-	quote_escape_json(ctx->out, prefix);
+	appendStringInfoString(&prefix_buffer, prefix);
+	quote_escape_json(ctx->out, prefix_buffer.data);
 
 	if (data->pretty_print)
 		appendStringInfoString(ctx->out, ",\n\t\t\t\"content\": ");
@@ -960,6 +963,7 @@ pg_decode_message(LogicalDecodingContext *ctx,
 		appendStringInfoChar(ctx->out, '}');
 
 	pfree(message_buffer.data);
+	pfree(prefix_buffer.data);
 
 	MemoryContextSwitchTo(old);
 	MemoryContextReset(data->context);

--- a/wal2json.c
+++ b/wal2json.c
@@ -72,10 +72,12 @@ static void pg_decode_commit_txn(LogicalDecodingContext *ctx,
 static void pg_decode_change(LogicalDecodingContext *ctx,
 				 ReorderBufferTXN *txn, Relation rel,
 				 ReorderBufferChange *change);
+#ifdef HAVE_LOGICAL_EMIT_MESSAGE
 static void pg_decode_message(LogicalDecodingContext *ctx,
 				 ReorderBufferTXN *txn, XLogRecPtr message_lsn,
 				 bool transactional, const char *prefix,
 				 Size sz, const char *message);
+#endif
 
 void
 _PG_init(void)
@@ -93,7 +95,9 @@ _PG_output_plugin_init(OutputPluginCallbacks *cb)
 	cb->change_cb = pg_decode_change;
 	cb->commit_cb = pg_decode_commit_txn;
 	cb->shutdown_cb = pg_decode_shutdown;
+#ifdef HAVE_LOGICAL_EMIT_MESSAGE
 	cb->message_cb = pg_decode_message;
+#endif
 }
 
 /* Initialize this plugin */

--- a/wal2json.c
+++ b/wal2json.c
@@ -941,13 +941,23 @@ pg_decode_message(LogicalDecodingContext *ctx,
 	if(data->pretty_print)
 	{
 		appendStringInfoString(ctx->out, "\t\t\t\"kind\": \"message\",\n");
-		appendStringInfo(ctx->out, "\t\t\t\"transactional\": \"%d\",\n", transactional);
+
+    if (transactional)
+      appendStringInfoString(ctx->out, "\t\t\t\"transactional\": true,\n");
+    else
+      appendStringInfoString(ctx->out, "\t\t\t\"transactional\": false,\n");
+
 		appendStringInfoString(ctx->out, "\t\t\t\"prefix\": ");
 	}
 	else
 	{
 		appendStringInfoString(ctx->out, "\"kind\":\"message\",");
-		appendStringInfo(ctx->out, "\"transactional\":\"%d\",", transactional);
+
+    if (transactional)
+      appendStringInfoString(ctx->out, "\"transactional\":true,");
+    else
+      appendStringInfoString(ctx->out, "\"transactional\":false,");
+
 		appendStringInfoString(ctx->out, "\"prefix\":");
 	}
 

--- a/wal2json.c
+++ b/wal2json.c
@@ -942,10 +942,10 @@ pg_decode_message(LogicalDecodingContext *ctx,
 	{
 		appendStringInfoString(ctx->out, "\t\t\t\"kind\": \"message\",\n");
 
-    if (transactional)
-      appendStringInfoString(ctx->out, "\t\t\t\"transactional\": true,\n");
-    else
-      appendStringInfoString(ctx->out, "\t\t\t\"transactional\": false,\n");
+		if (transactional)
+			appendStringInfoString(ctx->out, "\t\t\t\"transactional\": true,\n");
+		else
+			appendStringInfoString(ctx->out, "\t\t\t\"transactional\": false,\n");
 
 		appendStringInfoString(ctx->out, "\t\t\t\"prefix\": ");
 	}
@@ -953,10 +953,10 @@ pg_decode_message(LogicalDecodingContext *ctx,
 	{
 		appendStringInfoString(ctx->out, "\"kind\":\"message\",");
 
-    if (transactional)
-      appendStringInfoString(ctx->out, "\"transactional\":true,");
-    else
-      appendStringInfoString(ctx->out, "\"transactional\":false,");
+		if (transactional)
+			appendStringInfoString(ctx->out, "\"transactional\":true,");
+		else
+			appendStringInfoString(ctx->out, "\"transactional\":false,");
 
 		appendStringInfoString(ctx->out, "\"prefix\":");
 	}


### PR DESCRIPTION
In 9.6, the `pg_logical_emit_message` function sends arbitrary data to WAL for logical decoding. One can leverage this infrastructure to transactionally send application/domain events along with "change data capture" events. The events are presented like so:

```json
{"change":[{"kind":"message","transactional":"1","prefix":"foo","content":"bar"}]}
```

This change supports transactional messages and ignores non-transactional messages. (I left "transactional" in the JSON anticipating support for non-transactional messages in the future.)

This is useful for me, and I hope it is useful for others as well. Feedback welcome on any/all aspects.