### PR TITLE
Improve JSON encoding

### DIFF
--- a/expected/insert1.out
+++ b/expected/insert1.out
@@ -59,6 +59,12 @@ o	json,
 p	tsvector,
 UNIQUE(g, n)
 );
+CREATE SCHEMA "test ""schema";
+CREATE TABLE "test ""schema"."test "" with 'quotes'" (
+    id            serial primary key,
+    "col spaces"  int,
+    "col""quotes" int
+);
 SELECT 'init' FROM pg_create_logical_replication_slot('regression_slot', 'wal2json');
  ?column? 
 ----------
@@ -70,6 +76,7 @@ BEGIN;
 INSERT INTO table_with_pk (b, c, d, e, f, g, h, i, j, k, l, m, n, o, p) VALUES(1, 2, 3, 3.54, 876.563452345, 1.23, 'teste', 'testando', 'um texto longo', B'001110010101010', '2013-11-02 17:30:52', '2013-02-04', true, '{ "a": 123 }', 'Old Old Parr'::tsvector);
 INSERT INTO table_without_pk (b, c, d, e, f, g, h, i, j, k, l, m, n, o, p) VALUES(1, 2, 3, 3.54, 876.563452345, 1.23, 'teste', 'testando', 'um texto longo', B'001110010101010', '2013-11-02 17:30:52', '2013-02-04', true, '{ "a": 123 }', 'Old Old Parr'::tsvector);
 INSERT INTO table_with_unique (b, c, d, e, f, g, h, i, j, k, l, m, n, o, p) VALUES(1, 2, 3, 3.54, 876.563452345, 1.23, 'teste', 'testando', 'um texto longo', B'001110010101010', '2013-11-02 17:30:52', '2013-02-04', true, '{ "a": 123 }', 'Old Old Parr'::tsvector);
+INSERT INTO "test ""schema"."test "" with 'quotes'" VALUES (1, 2, 3);
 COMMIT;
 SELECT data FROM pg_logical_slot_get_changes('regression_slot', NULL, NULL, 'pretty-print', '1', 'include-typmod', '0');
                                                                                                             data                                                                                                             
@@ -99,6 +106,14 @@ SELECT data FROM pg_logical_slot_get_changes('regression_slot', NULL, NULL, 'pre
                          "columnnames": ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p"],                                                                                                   +
                          "columntypes": ["int2", "int2", "int4", "int8", "numeric", "float4", "float8", "bpchar", "varchar", "text", "varbit", "timestamp", "date", "bool", "json", "tsvector"],                            +
                          "columnvalues": [1, 1, 2, 3, 3.540, 876.563, 1.23, "teste     ", "testando", "um texto longo", "001110010101010", "Sat Nov 02 17:30:52 2013", "02-04-2013", true, "{ \"a\": 123 }", "'Old' 'Parr'"]+
+                 }                                                                                                                                                                                                          +
+                 ,{                                                                                                                                                                                                         +
+                         "kind": "insert",                                                                                                                                                                                  +
+                         "schema": "test \"schema",                                                                                                                                                                         +
+                         "table": "test \" with 'quotes'",                                                                                                                                                                  +
+                         "columnnames": ["id", "col spaces", "col\"quotes"],                                                                                                                                                +
+                         "columntypes": ["int4", "int4", "int4"],                                                                                                                                                           +
+                         "columnvalues": [1, 2, 3]                                                                                                                                                                          +
                  }                                                                                                                                                                                                          +
          ]                                                                                                                                                                                                                  +
  }

--- a/expected/message.out
+++ b/expected/message.out
@@ -19,37 +19,55 @@ SELECT 'msg2' FROM pg_logical_emit_message(false, 'wal2json', 'this is "another"
  msg2
 (1 row)
 
-BEGIN;
-SELECT 'msg3' FROM pg_logical_emit_message(true, 'wal2json', 'this message will not be printed');
+SELECT 'msg3' FROM pg_logical_emit_message(false, 'wal2json', E'\\x31320033003435'::bytea);
  ?column? 
 ----------
  msg3
 (1 row)
 
-SELECT 'msg4' FROM pg_logical_emit_message(false, 'wal2json', 'this message will be printed even if the transaction is rollbacked');
+SELECT 'msg4' FROM pg_logical_emit_message(false, 'wal2json', E'\\xC0FFEE00C0FFEE'::bytea);
  ?column? 
 ----------
  msg4
 (1 row)
 
-ROLLBACK;
-BEGIN;
-SELECT 'msg5' FROM pg_logical_emit_message(true, 'wal2json', 'this is message #1');
+SELECT 'msg5' FROM pg_logical_emit_message(false, 'wal2json', E'\\x01020300101112'::bytea);
  ?column? 
 ----------
  msg5
 (1 row)
 
-SELECT 'msg6' FROM pg_logical_emit_message(false, 'wal2json', 'this message will be printed before message #1');
+BEGIN;
+SELECT 'msg6' FROM pg_logical_emit_message(true, 'wal2json', 'this message will not be printed');
  ?column? 
 ----------
  msg6
 (1 row)
 
-SELECT 'msg7' FROM pg_logical_emit_message(true, 'wal2json', 'this is message #2');
+SELECT 'msg7' FROM pg_logical_emit_message(false, 'wal2json', 'this message will be printed even if the transaction is rollbacked');
  ?column? 
 ----------
  msg7
+(1 row)
+
+ROLLBACK;
+BEGIN;
+SELECT 'msg8' FROM pg_logical_emit_message(true, 'wal2json', 'this is message #1');
+ ?column? 
+----------
+ msg8
+(1 row)
+
+SELECT 'msg9' FROM pg_logical_emit_message(false, 'wal2json', 'this message will be printed before message #1');
+ ?column? 
+----------
+ msg9
+(1 row)
+
+SELECT 'msg10' FROM pg_logical_emit_message(true, 'wal2json', 'this is message #2');
+ ?column? 
+----------
+ msg10
 (1 row)
 
 COMMIT;
@@ -62,7 +80,7 @@ SELECT data FROM pg_logical_slot_get_changes('regression_slot', NULL, NULL, 'pre
                          "kind": "message",                                                             +
                          "transactional": true,                                                         +
                          "prefix": "wal2json",                                                          +
-                         "content": "this is a\ message"                                                +
+                         "content": "this is a\\ message"                                               +
                  }                                                                                      +
          ]                                                                                              +
  }
@@ -72,7 +90,37 @@ SELECT data FROM pg_logical_slot_get_changes('regression_slot', NULL, NULL, 'pre
                          "kind": "message",                                                             +
                          "transactional": false,                                                        +
                          "prefix": "wal2json",                                                          +
-                         "content": "this is "another" message"                                         +
+                         "content": "this is \"another\" message"                                       +
+                 }                                                                                      +
+         ]                                                                                              +
+ }
+ {                                                                                                      +
+         "change": [                                                                                    +
+                 {                                                                                      +
+                         "kind": "message",                                                             +
+                         "transactional": false,                                                        +
+                         "prefix": "wal2json",                                                          +
+                         "content": "12"                                                                +
+                 }                                                                                      +
+         ]                                                                                              +
+ }
+ {                                                                                                      +
+         "change": [                                                                                    +
+                 {                                                                                      +
+                         "kind": "message",                                                             +
+                         "transactional": false,                                                        +
+                         "prefix": "wal2json",                                                          +
+                         "content": ""                                                                  +
+                 }                                                                                      +
+         ]                                                                                              +
+ }
+ {                                                                                                      +
+         "change": [                                                                                    +
+                 {                                                                                      +
+                         "kind": "message",                                                             +
+                         "transactional": false,                                                        +
+                         "prefix": "wal2json",                                                          +
+                         "content": "\u0001\u0002\u0003"                                                +
                  }                                                                                      +
          ]                                                                                              +
  }
@@ -112,7 +160,7 @@ SELECT data FROM pg_logical_slot_get_changes('regression_slot', NULL, NULL, 'pre
                  }                                                                                      +
          ]                                                                                              +
  }
-(5 rows)
+(8 rows)
 
 SELECT 'stop' FROM pg_drop_replication_slot('regression_slot');
  ?column? 

--- a/expected/specialvalue.out
+++ b/expected/specialvalue.out
@@ -18,47 +18,47 @@ INSERT INTO xpto (b, c, d) VALUES(NULL, 'null', '-inf');
 INSERT INTO xpto (b, c, d) VALUES(TRUE, E'valid: '' " \\ / \b \f \n \r \t \u207F \u967F invalid: \\g \\k end', 123.456);
 COMMIT;
 SELECT data FROM pg_logical_slot_get_changes('regression_slot', NULL, NULL, 'pretty-print', '1', 'include-typmod', '0');
-                                                           data                                                           
---------------------------------------------------------------------------------------------------------------------------
- {                                                                                                                       +
-         "change": [                                                                                                     +
-         ]                                                                                                               +
+                                                          data                                                           
+-------------------------------------------------------------------------------------------------------------------------
+ {                                                                                                                      +
+         "change": [                                                                                                    +
+         ]                                                                                                              +
  }
- {                                                                                                                       +
-         "change": [                                                                                                     +
-                 {                                                                                                       +
-                         "kind": "insert",                                                                               +
-                         "schema": "public",                                                                             +
-                         "table": "xpto",                                                                                +
-                         "columnnames": ["a", "b", "c", "d"],                                                            +
-                         "columntypes": ["int4", "bool", "varchar", "float4"],                                           +
-                         "columnvalues": [1, true, "test1", null]                                                        +
-                 }                                                                                                       +
-                 ,{                                                                                                      +
-                         "kind": "insert",                                                                               +
-                         "schema": "public",                                                                             +
-                         "table": "xpto",                                                                                +
-                         "columnnames": ["a", "b", "c", "d"],                                                            +
-                         "columntypes": ["int4", "bool", "varchar", "float4"],                                           +
-                         "columnvalues": [2, false, "test2", null]                                                       +
-                 }                                                                                                       +
-                 ,{                                                                                                      +
-                         "kind": "insert",                                                                               +
-                         "schema": "public",                                                                             +
-                         "table": "xpto",                                                                                +
-                         "columnnames": ["a", "b", "c", "d"],                                                            +
-                         "columntypes": ["int4", "bool", "varchar", "float4"],                                           +
-                         "columnvalues": [3, null, "null", null]                                                         +
-                 }                                                                                                       +
-                 ,{                                                                                                      +
-                         "kind": "insert",                                                                               +
-                         "schema": "public",                                                                             +
-                         "table": "xpto",                                                                                +
-                         "columnnames": ["a", "b", "c", "d"],                                                            +
-                         "columntypes": ["int4", "bool", "varchar", "float4"],                                           +
-                         "columnvalues": [4, true, "valid: ' \" \\ \/ \b \f \n \r \t ⁿ 陿 invalid: \\g \\k end", 123.456]+
-                 }                                                                                                       +
-         ]                                                                                                               +
+ {                                                                                                                      +
+         "change": [                                                                                                    +
+                 {                                                                                                      +
+                         "kind": "insert",                                                                              +
+                         "schema": "public",                                                                            +
+                         "table": "xpto",                                                                               +
+                         "columnnames": ["a", "b", "c", "d"],                                                           +
+                         "columntypes": ["int4", "bool", "varchar", "float4"],                                          +
+                         "columnvalues": [1, true, "test1", null]                                                       +
+                 }                                                                                                      +
+                 ,{                                                                                                     +
+                         "kind": "insert",                                                                              +
+                         "schema": "public",                                                                            +
+                         "table": "xpto",                                                                               +
+                         "columnnames": ["a", "b", "c", "d"],                                                           +
+                         "columntypes": ["int4", "bool", "varchar", "float4"],                                          +
+                         "columnvalues": [2, false, "test2", null]                                                      +
+                 }                                                                                                      +
+                 ,{                                                                                                     +
+                         "kind": "insert",                                                                              +
+                         "schema": "public",                                                                            +
+                         "table": "xpto",                                                                               +
+                         "columnnames": ["a", "b", "c", "d"],                                                           +
+                         "columntypes": ["int4", "bool", "varchar", "float4"],                                          +
+                         "columnvalues": [3, null, "null", null]                                                        +
+                 }                                                                                                      +
+                 ,{                                                                                                     +
+                         "kind": "insert",                                                                              +
+                         "schema": "public",                                                                            +
+                         "table": "xpto",                                                                               +
+                         "columnnames": ["a", "b", "c", "d"],                                                           +
+                         "columntypes": ["int4", "bool", "varchar", "float4"],                                          +
+                         "columnvalues": [4, true, "valid: ' \" \\ / \b \f \n \r \t ⁿ 陿 invalid: \\g \\k end", 123.456]+
+                 }                                                                                                      +
+         ]                                                                                                              +
  }
 (2 rows)
 

--- a/sql/insert1.sql
+++ b/sql/insert1.sql
@@ -65,6 +65,14 @@ p	tsvector,
 UNIQUE(g, n)
 );
 
+CREATE SCHEMA "test ""schema";
+
+CREATE TABLE "test ""schema"."test "" with 'quotes'" (
+    id            serial primary key,
+    "col spaces"  int,
+    "col""quotes" int
+);
+
 SELECT 'init' FROM pg_create_logical_replication_slot('regression_slot', 'wal2json');
 
 -- INSERT
@@ -72,6 +80,7 @@ BEGIN;
 INSERT INTO table_with_pk (b, c, d, e, f, g, h, i, j, k, l, m, n, o, p) VALUES(1, 2, 3, 3.54, 876.563452345, 1.23, 'teste', 'testando', 'um texto longo', B'001110010101010', '2013-11-02 17:30:52', '2013-02-04', true, '{ "a": 123 }', 'Old Old Parr'::tsvector);
 INSERT INTO table_without_pk (b, c, d, e, f, g, h, i, j, k, l, m, n, o, p) VALUES(1, 2, 3, 3.54, 876.563452345, 1.23, 'teste', 'testando', 'um texto longo', B'001110010101010', '2013-11-02 17:30:52', '2013-02-04', true, '{ "a": 123 }', 'Old Old Parr'::tsvector);
 INSERT INTO table_with_unique (b, c, d, e, f, g, h, i, j, k, l, m, n, o, p) VALUES(1, 2, 3, 3.54, 876.563452345, 1.23, 'teste', 'testando', 'um texto longo', B'001110010101010', '2013-11-02 17:30:52', '2013-02-04', true, '{ "a": 123 }', 'Old Old Parr'::tsvector);
+INSERT INTO "test ""schema"."test "" with 'quotes'" VALUES (1, 2, 3);
 COMMIT;
 
 SELECT data FROM pg_logical_slot_get_changes('regression_slot', NULL, NULL, 'pretty-print', '1', 'include-typmod', '0');

--- a/sql/message.sql
+++ b/sql/message.sql
@@ -8,15 +8,19 @@ SELECT 'init' FROM pg_create_logical_replication_slot('regression_slot', 'wal2js
 SELECT 'msg1' FROM pg_logical_emit_message(true, 'wal2json', 'this is a\ message');
 SELECT 'msg2' FROM pg_logical_emit_message(false, 'wal2json', 'this is "another" message');
 
+SELECT 'msg3' FROM pg_logical_emit_message(false, 'wal2json', E'\\x31320033003435'::bytea);
+SELECT 'msg4' FROM pg_logical_emit_message(false, 'wal2json', E'\\xC0FFEE00C0FFEE'::bytea);
+SELECT 'msg5' FROM pg_logical_emit_message(false, 'wal2json', E'\\x01020300101112'::bytea);
+
 BEGIN;
-SELECT 'msg3' FROM pg_logical_emit_message(true, 'wal2json', 'this message will not be printed');
-SELECT 'msg4' FROM pg_logical_emit_message(false, 'wal2json', 'this message will be printed even if the transaction is rollbacked');
+SELECT 'msg6' FROM pg_logical_emit_message(true, 'wal2json', 'this message will not be printed');
+SELECT 'msg7' FROM pg_logical_emit_message(false, 'wal2json', 'this message will be printed even if the transaction is rollbacked');
 ROLLBACK;
 
 BEGIN;
-SELECT 'msg5' FROM pg_logical_emit_message(true, 'wal2json', 'this is message #1');
-SELECT 'msg6' FROM pg_logical_emit_message(false, 'wal2json', 'this message will be printed before message #1');
-SELECT 'msg7' FROM pg_logical_emit_message(true, 'wal2json', 'this is message #2');
+SELECT 'msg8' FROM pg_logical_emit_message(true, 'wal2json', 'this is message #1');
+SELECT 'msg9' FROM pg_logical_emit_message(false, 'wal2json', 'this message will be printed before message #1');
+SELECT 'msg10' FROM pg_logical_emit_message(true, 'wal2json', 'this is message #2');
 COMMIT;
 
 SELECT data FROM pg_logical_slot_get_changes('regression_slot', NULL, NULL, 'pretty-print', '1');


### PR DESCRIPTION
1. use the postgres builtin `escape_json()` function
2. escape all type, schema, table, field names. Add another test. Fixes #35 
3. escape generic logical decoding messages
4. leave `\x` alone unless it's a `bytea` prefix. Fixes #23, though like the reporter I'm not entirely convinced wal2json should be dropping the `\x` at all?

There's still a lot of duplicated code paths between "pretty" and "normal" modes. Personally I'd suggest dropping pretty-print mode from wal2json altogether and suggesting users pass it through [jq](https://stedolan.github.io/jq/) for debugging:
```
$ pg_recvlogical --slot test --start -o -o write-in-chunks=0 -f - | jq
```

Otherwise maybe some helper macros/functions that take care of the `\n\t` stuff so the duplication can be eliminated?