### PR TITLE
Add more options for xmins and nextxids

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ MODULES = wal2json
 # message test will fail for <= 9.5
 REGRESS = cmdline insert1 update1 update2 update3 update4 delete1 delete2 \
 		  delete3 delete4 savepoint specialvalue toast bytea message typmod \
-		  filtertable selecttable
+		  filtertable selecttable xmin nextxid
 
 PG_CONFIG = pg_config
 PGXS := $(shell $(PG_CONFIG) --pgxs)

--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ Parameters
 * `write-in-chunks`: write after every change instead of every changeset. Default is _false_.
 * `include-lsn`: add _nextlsn_ to each changeset. Default is _false_.
 * `include-unchanged-toast`: add TOAST value even if it was not modified. Since TOAST values are usually large, this option could save IO and bandwidth if it is disabled. Default is _true_.
+* `include-xmins`: Add slot _catxmin_ (catalog xmin) and _xmin_ to each changeset. Default is _false_.
+* `include-next-xids`: Adds _nextxid_ and _epoch_ (indicates xid wraparound) to each changeset. Default is _false_.
 * `filter-tables`: exclude rows from the specified tables. Default is empty which means that no table will be filtered. It is a comma separated value. The tables should be schema-qualified. `*.foo` means table foo in all schemas and `bar.*` means all tables in schema bar. Special characters (space, single quote, comma, period, asterisk) must be escaped with backslash. Schema and table are case-sensitive. Table `"public"."Foo bar"` should be specified as `public.Foo\ bar`.
 * `add-tables`: include only rows from the specified tables. Default is all tables from all schemas. It has the same rules from `filter-tables`.
 

--- a/expected/nextxid.out
+++ b/expected/nextxid.out
@@ -1,0 +1,31 @@
+\set VERBOSITY terse
+-- predictability
+SET synchronous_commit = on;
+SELECT 'init' FROM pg_create_logical_replication_slot('regression_slot', 'wal2json');
+ ?column? 
+----------
+ init
+(1 row)
+
+DROP TABLE IF EXISTS nextxid ;
+NOTICE:  table "nextxid" does not exist, skipping
+CREATE TABLE nextxid (id integer PRIMARY KEY);
+INSERT INTO nextxid values (1);
+-- convert 32 bit epoch and 32 bit xid into 64 bit from txid_current
+SELECT ((max(((data::json) -> 'epoch')::text::int)::bit(32) << 32) | max(((data::json) -> 'nextxid')::text::int)::bit(32))::bigint = txid_current() FROM pg_logical_slot_peek_changes('regression_slot', NULL, NULL, 'include-next-xids', '1');
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT data FROM pg_logical_slot_peek_changes('regression_slot', NULL, NULL) where ((data::json) -> 'nextxid') IS NOT NULL;
+ data 
+------
+(0 rows)
+
+SELECT 'stop' FROM pg_drop_replication_slot('regression_slot');
+ ?column? 
+----------
+ stop
+(1 row)
+

--- a/expected/xmin.out
+++ b/expected/xmin.out
@@ -1,0 +1,42 @@
+\set VERBOSITY terse
+-- predictability
+SET synchronous_commit = on;
+SELECT 'init' FROM pg_create_logical_replication_slot('regression_slot', 'wal2json');
+ ?column? 
+----------
+ init
+(1 row)
+
+DROP TABLE IF EXISTS xmin ;
+NOTICE:  table "xmin" does not exist, skipping
+CREATE TABLE xmin (id integer PRIMARY KEY);
+INSERT INTO xmin values (1);
+-- xmin is often (always?) 0, but this should be forward compat should that change in the future
+SELECT max(((data::json) -> 'xmin')::text::int) = (SELECT coalesce(xmin::text::int, 0) FROM pg_replication_slots WHERE slot_name = 'regression_slot') FROM pg_logical_slot_peek_changes('regression_slot', NULL, NULL, 'include-xmins', '1');
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT max(((data::json) -> 'catxmin')::text::int) = (SELECT catalog_xmin::text::int FROM pg_replication_slots WHERE slot_name = 'regression_slot') FROM pg_logical_slot_peek_changes('regression_slot', NULL, NULL, 'include-xmins', '1');
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT data FROM pg_logical_slot_peek_changes('regression_slot', NULL, NULL) where ((data::json) -> 'catxmin') IS NOT NULL;
+ data 
+------
+(0 rows)
+
+SELECT data FROM pg_logical_slot_peek_changes('regression_slot', NULL, NULL) where ((data::json) -> 'xmin') IS NOT NULL;
+ data 
+------
+(0 rows)
+
+SELECT 'stop' FROM pg_drop_replication_slot('regression_slot');
+ ?column? 
+----------
+ stop
+(1 row)
+

--- a/sql/nextxid.sql
+++ b/sql/nextxid.sql
@@ -1,0 +1,17 @@
+\set VERBOSITY terse
+
+-- predictability
+SET synchronous_commit = on;
+
+SELECT 'init' FROM pg_create_logical_replication_slot('regression_slot', 'wal2json');
+
+DROP TABLE IF EXISTS nextxid ;
+
+CREATE TABLE nextxid (id integer PRIMARY KEY);
+INSERT INTO nextxid values (1);
+
+-- convert 32 bit epoch and 32 bit xid into 64 bit from txid_current
+SELECT ((max(((data::json) -> 'epoch')::text::int)::bit(32) << 32) | max(((data::json) -> 'nextxid')::text::int)::bit(32))::bigint = txid_current() FROM pg_logical_slot_peek_changes('regression_slot', NULL, NULL, 'include-next-xids', '1');
+
+SELECT data FROM pg_logical_slot_peek_changes('regression_slot', NULL, NULL) where ((data::json) -> 'nextxid') IS NOT NULL;
+SELECT 'stop' FROM pg_drop_replication_slot('regression_slot');

--- a/sql/xmin.sql
+++ b/sql/xmin.sql
@@ -1,0 +1,19 @@
+\set VERBOSITY terse
+
+-- predictability
+SET synchronous_commit = on;
+
+SELECT 'init' FROM pg_create_logical_replication_slot('regression_slot', 'wal2json');
+
+DROP TABLE IF EXISTS xmin ;
+
+CREATE TABLE xmin (id integer PRIMARY KEY);
+INSERT INTO xmin values (1);
+
+-- xmin is often (always?) 0, but this should be forward compat should that change in the future
+SELECT max(((data::json) -> 'xmin')::text::int) = (SELECT coalesce(xmin::text::int, 0) FROM pg_replication_slots WHERE slot_name = 'regression_slot') FROM pg_logical_slot_peek_changes('regression_slot', NULL, NULL, 'include-xmins', '1');
+SELECT max(((data::json) -> 'catxmin')::text::int) = (SELECT catalog_xmin::text::int FROM pg_replication_slots WHERE slot_name = 'regression_slot') FROM pg_logical_slot_peek_changes('regression_slot', NULL, NULL, 'include-xmins', '1');
+
+SELECT data FROM pg_logical_slot_peek_changes('regression_slot', NULL, NULL) where ((data::json) -> 'catxmin') IS NOT NULL;
+SELECT data FROM pg_logical_slot_peek_changes('regression_slot', NULL, NULL) where ((data::json) -> 'xmin') IS NOT NULL;
+SELECT 'stop' FROM pg_drop_replication_slot('regression_slot');


### PR DESCRIPTION
This adds two more options for additional metadata into the slot:

- `include-xmins` This data includes the `catalog_xmin` and `xmin` fields
from the replication slot. The reasons for wanting this generally occurs when
using logical replication with a secondary. Since replication slots don't
get replicated to secondaries, in the event of the failover you need
some mechanism for seeing what records you may have missed. The
xmin/catalog_xmin is useful as you can use it for a lower bound and any
records with a higher xmin could have been missed
- `include-next-xids` This includes sending both the `epoch` and
`nextxid` 32-bit ints. The epoch is a number that increments when xid
rollover happens. This allows you to reconstruct the same txid you get
from the `txid_current` function which accounts for rollover. This can
be really useful to see at a point's time how far behind the slot you
currently are.