### PR TITLE
Add "How to get full row data" - REPLICA_IDENTITY

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,14 @@ Parameters
 * `filter-tables`: exclude rows from the specified tables. Default is empty which means that no table will be filtered. It is a comma separated value. The tables should be schema-qualified. `*.foo` means table foo in all schemas and `bar.*` means all tables in schema bar. Special characters (space, single quote, comma, period, asterisk) must be escaped with backslash. Schema and table are case-sensitive. Table `"public"."Foo bar"` should be specified as `public.Foo\ bar`.
 * `add-tables`: include only rows from the specified tables. Default is all tables from all schemas. It has the same rules from `filter-tables`.
 
+Obtaining the full rows rather than just changes
+------------------------------------------------
+
+By default, the WAL only contains the data needed to replicate the changes.
+If you need the whole row to appear in the exported JSON, set [`REPLICA IDENTITY FULL`](https://www.postgresql.org/docs/9.6/static/sql-altertable.html#SQL-CREATETABLE-REPLICA-IDENTITY):
+
+    ALTER TABLE myTable2 REPLICA IDENTITY FULL
+
 Examples
 ========
 


### PR DESCRIPTION
It's a bit natural to assume that this could be an option of wal2json, see issue #7. But it's not since one needs to configure the tables for that.
This could save people the time finding that out.