### PR TITLE
Add individual row LSNs to output.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,8 @@ MODULES = wal2json
 # message test will fail for <= 9.5
 REGRESS = cmdline insert1 update1 update2 update3 update4 delete1 delete2 \
 		  delete3 delete4 savepoint specialvalue toast bytea message typmod \
-		  filtertable selecttable include_timestamp include_lsn include_xids
+		  filtertable selecttable include_timestamp include_lsn include_xids \
+		  include_change_lsn
 
 PG_CONFIG = pg_config
 PGXS := $(shell $(PG_CONFIG) --pgxs)

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Parameters
 * `pretty-print`: add spaces and indentation to JSON structures. Default is _false_.
 * `write-in-chunks`: write after every change instead of every changeset. Default is _false_.
 * `include-lsn`: add _nextlsn_ to each changeset. Default is _false_.
+* `include-change-lsn`: include the _lsn_ location of each individual statement. Default is _false_.
 * `include-unchanged-toast` (deprecated): add TOAST value even if it was not modified. Since TOAST values are usually large, this option could save IO and bandwidth if it is disabled. Default is _true_.
 * `filter-tables`: exclude rows from the specified tables. Default is empty which means that no table will be filtered. It is a comma separated value. The tables should be schema-qualified. `*.foo` means table foo in all schemas and `bar.*` means all tables in schema bar. Special characters (space, single quote, comma, period, asterisk) must be escaped with backslash. Schema and table are case-sensitive. Table `"public"."Foo bar"` should be specified as `public.Foo\ bar`.
 * `add-tables`: include only rows from the specified tables. Default is all tables from all schemas. It has the same rules from `filter-tables`.

--- a/expected/include_change_lsn.out
+++ b/expected/include_change_lsn.out
@@ -1,0 +1,34 @@
+\set VERBOSITY terse
+-- predictability
+SET synchronous_commit = on;
+DROP TABLE IF EXISTS changelsn;
+NOTICE:  table "changelsn" does not exist, skipping
+CREATE TABLE changelsn (a SERIAL PRIMARY KEY, b bool, c varchar(60), d real);
+SELECT 'init' FROM pg_create_logical_replication_slot('regression_slot', 'wal2json');
+ ?column? 
+----------
+ init
+(1 row)
+
+INSERT INTO changelsn (b, c, d) VALUES('t', 'test1', '+inf');
+SELECT count(*) = 1, count(distinct((((data::json)->'change'->>0)::json -> 'lsn')::TEXT)) = 1 FROM pg_logical_slot_get_changes('regression_slot', NULL, NULL, 'include-change-lsn', '1');
+ ?column? | ?column? 
+----------+----------
+ t        | t
+(1 row)
+
+-- two rows should have two records and two distinct change lsns
+INSERT INTO changelsn (b, c, d) VALUES('f', 'test2', 'nan');
+DELETE FROM changelsn WHERE c = 'test1';
+SELECT count(*) = 2, count(distinct((((data::json)->'change'->>0)::json -> 'lsn')::TEXT)) = 2 FROM pg_logical_slot_get_changes('regression_slot', NULL, NULL, 'include-change-lsn', '1');
+ ?column? | ?column? 
+----------+----------
+ t        | t
+(1 row)
+
+SELECT 'stop' FROM pg_drop_replication_slot('regression_slot');
+ ?column? 
+----------
+ stop
+(1 row)
+

--- a/sql/include_change_lsn.sql
+++ b/sql/include_change_lsn.sql
@@ -1,0 +1,19 @@
+\set VERBOSITY terse
+
+-- predictability
+SET synchronous_commit = on;
+
+DROP TABLE IF EXISTS changelsn;
+CREATE TABLE changelsn (a SERIAL PRIMARY KEY, b bool, c varchar(60), d real);
+
+SELECT 'init' FROM pg_create_logical_replication_slot('regression_slot', 'wal2json');
+
+INSERT INTO changelsn (b, c, d) VALUES('t', 'test1', '+inf');
+SELECT count(*) = 1, count(distinct((((data::json)->'change'->>0)::json -> 'lsn')::TEXT)) = 1 FROM pg_logical_slot_get_changes('regression_slot', NULL, NULL, 'include-change-lsn', '1');
+
+-- two rows should have two records and two distinct change lsns
+INSERT INTO changelsn (b, c, d) VALUES('f', 'test2', 'nan');
+DELETE FROM changelsn WHERE c = 'test1';
+SELECT count(*) = 2, count(distinct((((data::json)->'change'->>0)::json -> 'lsn')::TEXT)) = 2 FROM pg_logical_slot_get_changes('regression_slot', NULL, NULL, 'include-change-lsn', '1');
+
+SELECT 'stop' FROM pg_drop_replication_slot('regression_slot');


### PR DESCRIPTION
This change adds an option to include the individual WAL location
(ReorderBufferChange->lsn) of each insert/update/delete statement in
the JSON change object.

    {
    	"change": [
    		{
    			"lsn": "0/1738B00",
    			"kind": "insert",
    			"schema": "public",
    			"table": "groups_group_members",
    			"columnnames": ["id", "group_id", "user_id"],
    			"columnvalues": [1, 1, 4]
    		}
      ]
    }