### PR TITLE
print primary key information for newly inserted rows

### DIFF
--- a/wal2json.c
+++ b/wal2json.c
@@ -932,6 +932,20 @@ pg_decode_change(LogicalDecodingContext *ctx, ReorderBufferTXN *txn,
 		case REORDER_BUFFER_CHANGE_INSERT:
 			/* Print the new tuple */
 			columns_to_stringinfo(ctx, tupdesc, &change->data.tp.newtuple->tuple, false);
+
+			/* Print identity infos */
+			indexrel = RelationIdGetRelation(relation->rd_replidindex);
+			if (indexrel != NULL)
+			{
+				indexdesc = RelationGetDescr(indexrel);
+				identity_to_stringinfo(ctx, tupdesc, &change->data.tp.newtuple->tuple, indexdesc);
+				RelationClose(indexrel);
+			}
+			else
+			{
+				identity_to_stringinfo(ctx, tupdesc, &change->data.tp.newtuple->tuple, NULL);
+			}
+
 			break;
 		case REORDER_BUFFER_CHANGE_UPDATE:
 			/* Print the new tuple */


### PR DESCRIPTION
This PR addresses issue #43 and mainly helps when replicating to key-value-stores.

For example, I transmit all changes to Kafka, with the key being a combination of schema name, table name, and primary key value(s). With this approach, I can cut the whole history back to the most recent state using Kafka's log compaction, whenever it grows too large. 