### PR TITLE
Improve perf on deletes when repl ident full

### DIFF
--- a/wal2json.c
+++ b/wal2json.c
@@ -553,6 +553,13 @@ tuple_to_stringinfo(LogicalDecodingContext *ctx, TupleDesc tupdesc, HeapTuple tu
 				continue;
 		}
 
+		/* Get Datum from tuple */
+		origval = heap_getattr(tuple, natt + 1, tupdesc, &isnull);
+
+		/* Skip nulls iif printing key/identity */
+		if (isnull && replident)
+			continue;
+
 		typid = attr->atttypid;
 
 		/* Figure out type name */
@@ -562,13 +569,6 @@ tuple_to_stringinfo(LogicalDecodingContext *ctx, TupleDesc tupdesc, HeapTuple tu
 
 		/* Get information needed for printing values of a type */
 		getTypeOutputInfo(typid, &typoutput, &typisvarlena);
-
-		/* Get Datum from tuple */
-		origval = heap_getattr(tuple, natt + 1, tupdesc, &isnull);
-
-		/* Skip nulls iif printing key/identity */
-		if (isnull && replident)
-			continue;
 
 		/* XXX Unchanged TOAST Datum does not need to be output */
 		if (!isnull && typisvarlena && VARATT_IS_EXTERNAL_ONDISK(origval))


### PR DESCRIPTION
In testing, calls to `getTypeOutputInfo` perform very poorly on columns that contain null values. When printing `oldkeys`, we actually skip columns with null values, so we should be able to move the sanity check higher up and avoid the `getTypeOutputInfo` call entirely (`heap_getattr` doesn't rely on any data from `getTypeOutputInfo`).

All of the existing tests are green.

Ran this benchmarking script to validate the fix:
https://github.com/rkrage/wal2json/blob/2e6f57c/bin/benchmark

**Current master:**

```
***** Benchmark results *****
transaction type: <builtin: TPC-B (sort of)>
scaling factor: 5
query mode: simple
number of clients: 1
number of threads: 1
number of transactions per client: 25000
number of transactions actually processed: 25000/25000
latency average = 1.668 ms
tps = 599.496293 (including connections establishing)
tps = 599.530363 (excluding connections establishing)

***** Total WAL size *****
 1136 MB

***** Replication slot read time *****

real    11m32.426s
user    0m2.610s
sys     0m5.500s

***** Replication slot output size *****
773M
```

**This PR:**

```
***** Benchmark results *****
transaction type: <builtin: TPC-B (sort of)>
scaling factor: 5
query mode: simple
number of clients: 1
number of threads: 1
number of transactions per client: 25000
number of transactions actually processed: 25000/25000
latency average = 1.741 ms
tps = 574.333875 (including connections establishing)
tps = 574.361094 (excluding connections establishing)

***** Total WAL size *****
 1136 MB

***** Replication slot read time *****

real    0m26.431s
user    0m1.360s
sys     0m3.700s

***** Replication slot output size *****
773M
```