### PR TITLE
Add Travis CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,31 @@
+---
+sudo: required
+
+branches:
+  only:
+    - travis-builds
+
+env:
+  matrix:
+    - PG_VERSION=9.4
+    - PG_VERSION=9.5
+    - PG_VERSION=9.6
+    - PG_VERSION=10
+    - PG_VERSION=11
+
+language: c
+
+services:
+  - docker
+
+before_install:
+  - docker pull dpirotte/postgres-dev:stretch
+
+script:
+  - >
+    docker run --rm -it \
+      -v $PWD:/build -w /build \
+      -e PATH=/usr/lib/postgresql/$PG_VERSION/bin:/usr/bin:/bin \
+      dpirotte/postgres-dev:stretch \
+      bash -c "pg_ctlcluster $PG_VERSION main start && \
+               make clean all install installcheck"

--- a/Makefile
+++ b/Makefile
@@ -2,12 +2,19 @@ MODULES = wal2json
 
 # message test will fail for <= 9.5
 REGRESS = cmdline insert1 update1 update2 update3 update4 delete1 delete2 \
-		  delete3 delete4 savepoint specialvalue toast bytea message typmod \
+		  delete3 delete4 savepoint specialvalue toast bytea typmod \
 		  filtertable selecttable
 
 PG_CONFIG = pg_config
 PGXS := $(shell $(PG_CONFIG) --pgxs)
 include $(PGXS)
+
+HAS_MESSAGE = $(shell $(PG_CONFIG) --version | grep -qE " 9\.4| 9\.5" && echo no || echo yes)
+
+ifeq ($(HAS_MESSAGE),yes)
+REGRESS += message
+endif
+
 
 # make installcheck
 #


### PR DESCRIPTION
This adds a Travis configuration that builds wal2json against all supported versions of Postgres on current stable Debian (stretch). A small Makefile change skips the `pg_logical_emit_message` tests on 9.4 and 9.5.

@eulerto You would need to set this up in Travis on your side to get builds for PRs and whatnot.