### PR TITLE
Optionally filter output to locally originating rows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,10 @@
 MODULES = wal2json
 
 # message test will fail for <= 9.5
+# only_local test will fail for 9.4
 REGRESS = cmdline insert1 update1 update2 update3 update4 delete1 delete2 \
 		  delete3 delete4 savepoint specialvalue toast bytea message typmod \
-		  filtertable selecttable
+		  filtertable selecttable only_local
 
 PG_CONFIG = pg_config
 PGXS := $(shell $(PG_CONFIG) --pgxs)

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Parameters
 * `include-unchanged-toast`: add TOAST value even if it was not modified. Since TOAST values are usually large, this option could save IO and bandwidth if it is disabled. Default is _true_.
 * `filter-tables`: exclude rows from the specified tables. Default is empty which means that no table will be filtered. It is a comma separated value. The tables should be schema-qualified. `*.foo` means table foo in all schemas and `bar.*` means all tables in schema bar. Special characters (space, single quote, comma, period, asterisk) must be escaped with backslash. Schema and table are case-sensitive. Table `"public"."Foo bar"` should be specified as `public.Foo\ bar`.
 * `add-tables`: include only rows from the specified tables. Default is all tables from all schemas. It has the same rules from `filter-tables`.
+* `only-local`: only include rows originating from the local node, skipping rows replayed onto this node via logical replication
 
 Examples
 ========

--- a/expected/only_local.out
+++ b/expected/only_local.out
@@ -1,0 +1,57 @@
+\set VERBOSITY terse
+-- predictability
+SET synchronous_commit = on;
+CREATE TABLE t (a int);
+SELECT pg_replication_origin_create('repl');
+ pg_replication_origin_create 
+------------------------------
+                            1
+(1 row)
+
+SELECT 'init' FROM pg_create_logical_replication_slot('regression_slot', 'wal2json');
+ ?column? 
+----------
+ init
+(1 row)
+
+INSERT INTO t VALUES (1);
+SELECT pg_replication_origin_session_setup('repl');
+ pg_replication_origin_session_setup 
+-------------------------------------
+ 
+(1 row)
+
+BEGIN;
+SELECT pg_replication_origin_xact_setup('0/1234567', current_timestamp);
+ pg_replication_origin_xact_setup 
+----------------------------------
+ 
+(1 row)
+
+INSERT INTO t VALUES (2);
+COMMIT;
+SELECT pg_replication_origin_session_reset();
+ pg_replication_origin_session_reset 
+-------------------------------------
+ 
+(1 row)
+
+INSERT INTO t VALUES (3);
+\a
+\t
+SELECT data FROM pg_logical_slot_peek_changes('regression_slot', NULL, NULL);
+{"change":[{"kind":"insert","schema":"public","table":"t","columnnames":["a"],"columntypes":["integer"],"columnvalues":[1]}]}
+{"change":[{"kind":"insert","schema":"public","table":"t","columnnames":["a"],"columntypes":["integer"],"columnvalues":[2]}]}
+{"change":[{"kind":"insert","schema":"public","table":"t","columnnames":["a"],"columntypes":["integer"],"columnvalues":[3]}]}
+SELECT data FROM pg_logical_slot_get_changes('regression_slot', NULL, NULL, 'only-local', '1');
+{"change":[{"kind":"insert","schema":"public","table":"t","columnnames":["a"],"columntypes":["integer"],"columnvalues":[1]}]}
+{"change":[{"kind":"insert","schema":"public","table":"t","columnnames":["a"],"columntypes":["integer"],"columnvalues":[3]}]}
+\a
+\t
+SELECT 'stop' FROM pg_drop_replication_slot('regression_slot');
+ ?column? 
+----------
+ stop
+(1 row)
+
+DROP TABLE t;

--- a/sql/only_local.sql
+++ b/sql/only_local.sql
@@ -1,0 +1,31 @@
+\set VERBOSITY terse
+
+-- predictability
+SET synchronous_commit = on;
+
+CREATE TABLE t (a int);
+SELECT pg_replication_origin_create('repl');
+
+SELECT 'init' FROM pg_create_logical_replication_slot('regression_slot', 'wal2json');
+
+INSERT INTO t VALUES (1);
+
+SELECT pg_replication_origin_session_setup('repl');
+BEGIN;
+SELECT pg_replication_origin_xact_setup('0/1234567', current_timestamp);
+INSERT INTO t VALUES (2);
+COMMIT;
+SELECT pg_replication_origin_session_reset();
+
+INSERT INTO t VALUES (3);
+
+\a
+\t
+SELECT data FROM pg_logical_slot_peek_changes('regression_slot', NULL, NULL);
+SELECT data FROM pg_logical_slot_get_changes('regression_slot', NULL, NULL, 'only-local', '1');
+\a
+\t
+
+SELECT 'stop' FROM pg_drop_replication_slot('regression_slot');
+
+DROP TABLE t;

--- a/wal2json.c
+++ b/wal2json.c
@@ -25,7 +25,6 @@
 #include "utils/syscache.h"
 
 #if PG_VERSION_NUM >= 90500
-#define HAS_FILTER_BY_ORIGIN
 #include "replication/origin.h"
 #endif
 
@@ -85,7 +84,7 @@ static void pg_decode_commit_txn(LogicalDecodingContext *ctx,
 static void pg_decode_change(LogicalDecodingContext *ctx,
 				 ReorderBufferTXN *txn, Relation rel,
 				 ReorderBufferChange *change);
-#ifdef HAS_FILTER_BY_ORIGIN
+#if PG_VERSION_NUM >= 90500
 static bool pg_decode_filter(LogicalDecodingContext *ctx, RepOriginId origin_id);
 #endif
 #if	PG_VERSION_NUM >= 90600
@@ -114,7 +113,7 @@ _PG_output_plugin_init(OutputPluginCallbacks *cb)
 	cb->change_cb = pg_decode_change;
 	cb->commit_cb = pg_decode_commit_txn;
 	cb->shutdown_cb = pg_decode_shutdown;
-#ifdef HAS_FILTER_BY_ORIGIN
+#if PG_VERSION_NUM >= 90500
  	cb->filter_by_origin_cb = pg_decode_filter;
 #endif
 #if	PG_VERSION_NUM >= 90600
@@ -463,7 +462,7 @@ pg_decode_commit_txn(LogicalDecodingContext *ctx, ReorderBufferTXN *txn,
 	OutputPluginWrite(ctx, true);
 }
 
-#ifdef HAS_FILTER_BY_ORIGIN
+#if PG_VERSION_NUM >= 90500
 static bool
 pg_decode_filter(LogicalDecodingContext *ctx, RepOriginId origin_id)
 {


### PR DESCRIPTION
Implement the `only-local` option as it is done in the built-in
`test_decoding` output plugin. Rows created by logical replication that
properly sets a replication origin (e.g. PUBLICATION/SUBSCRIPTION
infrastructure) will not generate logical output while `only-local` is
in use.