### PR TITLE
Add tests for timestamp, lsn, xids options

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ MODULES = wal2json
 # message test will fail for <= 9.5
 REGRESS = cmdline insert1 update1 update2 update3 update4 delete1 delete2 \
 		  delete3 delete4 savepoint specialvalue toast bytea message typmod \
-		  filtertable selecttable include_timestamp
+		  filtertable selecttable include_timestamp include_lsn
 
 PG_CONFIG = pg_config
 PGXS := $(shell $(PG_CONFIG) --pgxs)

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ MODULES = wal2json
 # message test will fail for <= 9.5
 REGRESS = cmdline insert1 update1 update2 update3 update4 delete1 delete2 \
 		  delete3 delete4 savepoint specialvalue toast bytea message typmod \
-		  filtertable selecttable include_timestamp include_lsn
+		  filtertable selecttable include_timestamp include_lsn include_xids
 
 PG_CONFIG = pg_config
 PGXS := $(shell $(PG_CONFIG) --pgxs)

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ MODULES = wal2json
 # message test will fail for <= 9.5
 REGRESS = cmdline insert1 update1 update2 update3 update4 delete1 delete2 \
 		  delete3 delete4 savepoint specialvalue toast bytea message typmod \
-		  filtertable selecttable
+		  filtertable selecttable include_timestamp
 
 PG_CONFIG = pg_config
 PGXS := $(shell $(PG_CONFIG) --pgxs)

--- a/expected/include_lsn.out
+++ b/expected/include_lsn.out
@@ -1,0 +1,42 @@
+\set VERBOSITY terse
+-- predictability
+SET synchronous_commit = on;
+DROP TABLE IF EXISTS tbl;
+CREATE TABLE tbl (id int);
+SELECT 'init' FROM pg_create_logical_replication_slot('regression_slot', 'wal2json');
+ ?column? 
+----------
+ init
+(1 row)
+
+-- One row should have one record and one nextlsn
+INSERT INTO tbl VALUES (1);
+SELECT count(*) = 1, count(distinct ((data::json)->'nextlsn')::text) = 1 FROM pg_logical_slot_get_changes('regression_slot', NULL, NULL, 'include-lsn', '1');
+ ?column? | ?column? 
+----------+----------
+ t        | t
+(1 row)
+
+-- Two rows should have two records and two nextlsns
+INSERT INTO tbl VALUES (2);
+INSERT INTO tbl VALUES (3);
+SELECT count(*) = 2, count(distinct ((data::json)->'nextlsn')::text) = 2 FROM pg_logical_slot_get_changes('regression_slot', NULL, NULL, 'include-lsn', '1');
+ ?column? | ?column? 
+----------+----------
+ t        | t
+(1 row)
+
+-- Two rows in one transaction should have one record and one nextlsn
+INSERT INTO tbl VALUES (4), (5);
+SELECT count(*) = 1, count(distinct ((data::json)->'nextlsn')::text) = 1 FROM pg_logical_slot_get_changes('regression_slot', NULL, NULL, 'include-lsn', '1');
+ ?column? | ?column? 
+----------+----------
+ t        | t
+(1 row)
+
+SELECT 'stop' FROM pg_drop_replication_slot('regression_slot');
+ ?column? 
+----------
+ stop
+(1 row)
+

--- a/expected/include_timestamp.out
+++ b/expected/include_timestamp.out
@@ -1,0 +1,43 @@
+\set VERBOSITY terse
+-- predictability
+SET synchronous_commit = on;
+DROP TABLE IF EXISTS tbl;
+NOTICE:  table "tbl" does not exist, skipping
+CREATE TABLE tbl (id int);
+SELECT 'init' FROM pg_create_logical_replication_slot('regression_slot', 'wal2json');
+ ?column? 
+----------
+ init
+(1 row)
+
+-- One row should have one record and one timestmap
+INSERT INTO tbl VALUES (1);
+SELECT count(*) = 1, count(distinct ((data::json)->'timestamp')::text) = 1 FROM pg_logical_slot_get_changes('regression_slot', NULL, NULL, 'include-timestamp', '1');
+ ?column? | ?column? 
+----------+----------
+ t        | t
+(1 row)
+
+-- Two rows should have two records and two timestamps
+INSERT INTO tbl VALUES (2);
+INSERT INTO tbl VALUES (3);
+SELECT count(*) = 2, count(distinct ((data::json)->'timestamp')::text) = 2 FROM pg_logical_slot_get_changes('regression_slot', NULL, NULL, 'include-timestamp', '1');
+ ?column? | ?column? 
+----------+----------
+ t        | t
+(1 row)
+
+-- Two rows in one transaction should have one record and one timestamp
+INSERT INTO tbl VALUES (4), (5);
+SELECT count(*) = 1, count(distinct ((data::json)->'timestamp')::text) = 1 FROM pg_logical_slot_get_changes('regression_slot', NULL, NULL, 'include-timestamp', '1');
+ ?column? | ?column? 
+----------+----------
+ t        | t
+(1 row)
+
+SELECT 'stop' FROM pg_drop_replication_slot('regression_slot');
+ ?column? 
+----------
+ stop
+(1 row)
+

--- a/expected/include_xids.out
+++ b/expected/include_xids.out
@@ -1,0 +1,42 @@
+\set VERBOSITY terse
+-- predictability
+SET synchronous_commit = on;
+DROP TABLE IF EXISTS tbl;
+CREATE TABLE tbl (id int);
+SELECT 'init' FROM pg_create_logical_replication_slot('regression_slot', 'wal2json');
+ ?column? 
+----------
+ init
+(1 row)
+
+-- One row should have one record and one xids
+INSERT INTO tbl VALUES (1);
+SELECT count(*) = 1, count(distinct ((data::json)->'xid')::text) = 1 FROM pg_logical_slot_get_changes('regression_slot', NULL, NULL, 'include-xids', '1');
+ ?column? | ?column? 
+----------+----------
+ t        | t
+(1 row)
+
+-- Two rows should have two records and two xids
+INSERT INTO tbl VALUES (2);
+INSERT INTO tbl VALUES (3);
+SELECT count(*) = 2, count(distinct ((data::json)->'xid')::text) = 2 FROM pg_logical_slot_get_changes('regression_slot', NULL, NULL, 'include-xids', '1');
+ ?column? | ?column? 
+----------+----------
+ t        | t
+(1 row)
+
+-- Two rows in one transaction should have one record and one xid
+INSERT INTO tbl VALUES (4), (5);
+SELECT count(*) = 2, count(distinct ((data::json)->'xid')::text) = 1 FROM pg_logical_slot_get_changes('regression_slot', NULL, NULL, 'include-xids', '1');
+ ?column? | ?column? 
+----------+----------
+ f        | t
+(1 row)
+
+SELECT 'stop' FROM pg_drop_replication_slot('regression_slot');
+ ?column? 
+----------
+ stop
+(1 row)
+

--- a/sql/include_lsn.sql
+++ b/sql/include_lsn.sql
@@ -1,0 +1,25 @@
+\set VERBOSITY terse
+
+-- predictability
+SET synchronous_commit = on;
+
+DROP TABLE IF EXISTS tbl;
+CREATE TABLE tbl (id int);
+
+SELECT 'init' FROM pg_create_logical_replication_slot('regression_slot', 'wal2json');
+
+-- One row should have one record and one nextlsn
+INSERT INTO tbl VALUES (1);
+SELECT count(*) = 1, count(distinct ((data::json)->'nextlsn')::text) = 1 FROM pg_logical_slot_get_changes('regression_slot', NULL, NULL, 'include-lsn', '1');
+
+-- Two rows should have two records and two nextlsns
+INSERT INTO tbl VALUES (2);
+INSERT INTO tbl VALUES (3);
+SELECT count(*) = 2, count(distinct ((data::json)->'nextlsn')::text) = 2 FROM pg_logical_slot_get_changes('regression_slot', NULL, NULL, 'include-lsn', '1');
+
+-- Two rows in one transaction should have one record and one nextlsn
+INSERT INTO tbl VALUES (4), (5);
+SELECT count(*) = 1, count(distinct ((data::json)->'nextlsn')::text) = 1 FROM pg_logical_slot_get_changes('regression_slot', NULL, NULL, 'include-lsn', '1');
+
+SELECT 'stop' FROM pg_drop_replication_slot('regression_slot');
+

--- a/sql/include_timestamp.sql
+++ b/sql/include_timestamp.sql
@@ -1,0 +1,25 @@
+\set VERBOSITY terse
+
+-- predictability
+SET synchronous_commit = on;
+
+DROP TABLE IF EXISTS tbl;
+CREATE TABLE tbl (id int);
+
+SELECT 'init' FROM pg_create_logical_replication_slot('regression_slot', 'wal2json');
+
+-- One row should have one record and one timestmap
+INSERT INTO tbl VALUES (1);
+SELECT count(*) = 1, count(distinct ((data::json)->'timestamp')::text) = 1 FROM pg_logical_slot_get_changes('regression_slot', NULL, NULL, 'include-timestamp', '1');
+
+-- Two rows should have two records and two timestamps
+INSERT INTO tbl VALUES (2);
+INSERT INTO tbl VALUES (3);
+SELECT count(*) = 2, count(distinct ((data::json)->'timestamp')::text) = 2 FROM pg_logical_slot_get_changes('regression_slot', NULL, NULL, 'include-timestamp', '1');
+
+-- Two rows in one transaction should have one record and one timestamp
+INSERT INTO tbl VALUES (4), (5);
+SELECT count(*) = 1, count(distinct ((data::json)->'timestamp')::text) = 1 FROM pg_logical_slot_get_changes('regression_slot', NULL, NULL, 'include-timestamp', '1');
+
+SELECT 'stop' FROM pg_drop_replication_slot('regression_slot');
+

--- a/sql/include_xids.sql
+++ b/sql/include_xids.sql
@@ -1,0 +1,25 @@
+\set VERBOSITY terse
+
+-- predictability
+SET synchronous_commit = on;
+
+DROP TABLE IF EXISTS tbl;
+CREATE TABLE tbl (id int);
+
+SELECT 'init' FROM pg_create_logical_replication_slot('regression_slot', 'wal2json');
+
+-- One row should have one record and one xids
+INSERT INTO tbl VALUES (1);
+SELECT count(*) = 1, count(distinct ((data::json)->'xid')::text) = 1 FROM pg_logical_slot_get_changes('regression_slot', NULL, NULL, 'include-xids', '1');
+
+-- Two rows should have two records and two xids
+INSERT INTO tbl VALUES (2);
+INSERT INTO tbl VALUES (3);
+SELECT count(*) = 2, count(distinct ((data::json)->'xid')::text) = 2 FROM pg_logical_slot_get_changes('regression_slot', NULL, NULL, 'include-xids', '1');
+
+-- Two rows in one transaction should have one record and one xid
+INSERT INTO tbl VALUES (4), (5);
+SELECT count(*) = 2, count(distinct ((data::json)->'xid')::text) = 1 FROM pg_logical_slot_get_changes('regression_slot', NULL, NULL, 'include-xids', '1');
+
+SELECT 'stop' FROM pg_drop_replication_slot('regression_slot');
+


### PR DESCRIPTION
Adding tests for existing options:
 - `include-timestamp`
 - `include-lsn`
 - `include-xids`

Authorship note:  I'm doing the legwork of assembling this PR from my organization's (Braintree) fork, but maintaining the original authorship of the individual commits.