### PR TITLE
Avoid null pointer dereference with empty filter-tables

### DIFF
--- a/wal2json.c
+++ b/wal2json.c
@@ -317,17 +317,20 @@ pg_decode_startup(LogicalDecodingContext *ctx, OutputPluginOptions *opt, bool is
 				elog(DEBUG1, "filter-tables argument is null");
 				data->filter_tables = NIL;
 			}
-
-			rawstr = pstrdup(strVal(elem->arg));
-			if (!string_to_SelectTable(rawstr, ',', &data->filter_tables))
+			else
 			{
+
+				rawstr = pstrdup(strVal(elem->arg));
+				if (!string_to_SelectTable(rawstr, ',', &data->filter_tables))
+				{
+					pfree(rawstr);
+					ereport(ERROR,
+							(errcode(ERRCODE_INVALID_NAME),
+							 errmsg("could not parse value \"%s\" for parameter \"%s\"",
+								 strVal(elem->arg), elem->defname)));
+				}
 				pfree(rawstr);
-				ereport(ERROR,
-						(errcode(ERRCODE_INVALID_NAME),
-						 errmsg("could not parse value \"%s\" for parameter \"%s\"",
-							 strVal(elem->arg), elem->defname)));
 			}
-			pfree(rawstr);
 		}
 		else if (strcmp(elem->defname, "add-tables") == 0)
 		{


### PR DESCRIPTION
As spotted by clang:
```
wal2json.c:321:21: warning: Dereference of null pointer
                        rawstr = pstrdup(strVal(elem->arg));
                                         ^~~~~~~~~~~~~~~~~
/usr/include/postgresql/11/server/nodes/value.h:54:20: note: expanded from macro 'strVal'
```