### PR TITLE
Never output a leading comma before non-transactional messages

### DIFF
--- a/expected/message.out
+++ b/expected/message.out
@@ -71,6 +71,20 @@ SELECT 'msg10' FROM pg_logical_emit_message(true, 'wal2json', 'this is message #
 (1 row)
 
 COMMIT;
+SELECT 'msg11' FROM pg_logical_emit_message(false, 'wal2json', 'this message is outside of a transaction');
+ ?column? 
+----------
+ msg11
+(1 row)
+
+BEGIN;
+SELECT 'msg12' FROM pg_logical_emit_message(true, 'wal2json', 'this message will be printed last');
+ ?column? 
+----------
+ msg12
+(1 row)
+
+COMMIT;
 SELECT data FROM pg_logical_slot_get_changes('regression_slot', NULL, NULL, 'pretty-print', '1');
                                                   data                                                   
 ---------------------------------------------------------------------------------------------------------
@@ -160,7 +174,27 @@ SELECT data FROM pg_logical_slot_get_changes('regression_slot', NULL, NULL, 'pre
                  }                                                                                      +
          ]                                                                                              +
  }
-(8 rows)
+ {                                                                                                      +
+         "change": [                                                                                    +
+                 {                                                                                      +
+                         "kind": "message",                                                             +
+                         "transactional": false,                                                        +
+                         "prefix": "wal2json",                                                          +
+                         "content": "this message is outside of a transaction"                          +
+                 }                                                                                      +
+         ]                                                                                              +
+ }
+ {                                                                                                      +
+         "change": [                                                                                    +
+                 {                                                                                      +
+                         "kind": "message",                                                             +
+                         "transactional": true,                                                         +
+                         "prefix": "wal2json",                                                          +
+                         "content": "this message will be printed last"                                 +
+                 }                                                                                      +
+         ]                                                                                              +
+ }
+(10 rows)
 
 SELECT 'stop' FROM pg_drop_replication_slot('regression_slot');
  ?column? 

--- a/sql/message.sql
+++ b/sql/message.sql
@@ -23,6 +23,12 @@ SELECT 'msg9' FROM pg_logical_emit_message(false, 'wal2json', 'this message will
 SELECT 'msg10' FROM pg_logical_emit_message(true, 'wal2json', 'this is message #2');
 COMMIT;
 
+SELECT 'msg11' FROM pg_logical_emit_message(false, 'wal2json', 'this message is outside of a transaction');
+
+BEGIN;
+SELECT 'msg12' FROM pg_logical_emit_message(true, 'wal2json', 'this message will be printed last');
+COMMIT;
+
 SELECT data FROM pg_logical_slot_get_changes('regression_slot', NULL, NULL, 'pretty-print', '1');
 
 SELECT 'stop' FROM pg_drop_replication_slot('regression_slot');

--- a/wal2json.c
+++ b/wal2json.c
@@ -1040,7 +1040,7 @@ pg_decode_message(LogicalDecodingContext *ctx, ReorderBufferTXN *txn,
 
 	appendStringInfo(ctx->out, "%s%s", data->ht, data->ht);
 
-	if (data->nr_changes > 1)
+	if (transactional && data->nr_changes > 1)
 		appendStringInfoChar(ctx->out, ',');
 
 	appendStringInfo(ctx->out, "{%s%s%s%s\"kind\":%s\"message\",%s", data->nl, data->ht, data->ht, data->ht, data->sp, data->nl);


### PR DESCRIPTION
Non-transactional messages can arrive after a transaction commit but before the next begin.  nr_changes is only reset to zero in begin_txn.  Perhaps it would be safer to reset nr_changes in commit_txn instead?