### PR TITLE
Fix add-tables to filter single-character schemas

### DIFF
--- a/wal2json.c
+++ b/wal2json.c
@@ -1128,7 +1128,7 @@ parse_table_identifier(List *qualified_tables, char separator, List **select_tab
 		 * schema named "*" thus this test should be before we remove the
 		 * escape character.
 		 */
-		if (str[0] == '*' || str[1] == '.')
+		if (str[0] == '*' && str[1] == '.')
 			t->allschemas = true;
 		else
 			t->allschemas = false;


### PR DESCRIPTION
This is more of an issue than a PR.

I have a test suite that uses schema names `a`, `b`, `c` and it seems if I use `'add-tables', 'b.*'` changes to the table `c.person` will still come through even though they should be filtered by the `add-tables` whitelist.

I think the bug is in this line:

https://github.com/eulerto/wal2json/blob/b4e7f41395efa787b4c4d6eaae4cc2496357edec/wal2json.c#L1131

I think it should be rather:

```c
		if (str[0] == '*' && str[1] == '.')
```

To reproduce:

```sql
drop schema if exists b,c cascade;

create schema b;
create schema c;
create table c.person (id serial primary key);

SELECT 'init' FROM pg_create_logical_replication_slot('single_character_schema_issue', 'wal2json');
insert into c.person default values;
SELECT data FROM pg_logical_slot_peek_changes('single_character_schema_issue', NULL, NULL, 'pretty-print', '1', 'add-tables', 'b.*');
SELECT 'stop' FROM pg_drop_replication_slot('single_character_schema_issue');
```