### PR TITLE
Add support for replication lag metrics

### DIFF
--- a/wal2json.c
+++ b/wal2json.c
@@ -874,6 +874,7 @@ static void
 pg_decode_commit_txn(LogicalDecodingContext *ctx, ReorderBufferTXN *txn,
 					 XLogRecPtr commit_lsn)
 {
+	OutputPluginUpdateProgress(ctx);
 	JsonDecodingData *data = ctx->output_plugin_private;
 
 	elog(DEBUG2, "my change counter: " UINT64_FORMAT " ; # of changes: " UINT64_FORMAT " ; # of changes in memory: " UINT64_FORMAT, data->nr_changes, txn->nentries, txn->nentries_mem);


### PR DESCRIPTION
The view "pg_stat_repliation" contains 3 metric fields "write_lag", "flush_lag", "replay_lag" for monitoring replication lag.
It works on pgoutput plugin, but wal2json doesn't support