### PR TITLE
Add support for replication lag metrics(pg10+)

### DIFF
--- a/wal2json.c
+++ b/wal2json.c
@@ -874,7 +874,11 @@ static void
 pg_decode_commit_txn(LogicalDecodingContext *ctx, ReorderBufferTXN *txn,
 					 XLogRecPtr commit_lsn)
 {
+
 	JsonDecodingData *data = ctx->output_plugin_private;
+#if PG_VERSION_NUM >= 100000
+	OutputPluginUpdateProgress(ctx);
+#endif
 
 	elog(DEBUG2, "my change counter: " UINT64_FORMAT " ; # of changes: " UINT64_FORMAT " ; # of changes in memory: " UINT64_FORMAT, data->nr_changes, txn->nentries, txn->nentries_mem);
 	elog(DEBUG2, "# of subxacts: %d", txn->nsubtxns);


### PR DESCRIPTION
The view "pg_stat_repliation" of PG10+ contains 3 metric fields "write_lag", "flush_lag", "replay_lag" for monitoring replication lag.
It works on pgoutput plugin, but wal2json doesn't support