### PR TITLE
Add include-type-oids support in format-version 2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,8 @@ MODULES = wal2json
 REGRESS = cmdline insert1 update1 update2 update3 update4 delete1 delete2 \
 		  delete3 delete4 savepoint specialvalue toast bytea message typmod \
 		  filtertable selecttable include_timestamp include_lsn include_xids \
-		  include_domain_data_type truncate actions position default pk rename_column
+		  include_domain_data_type truncate type_oid actions position default \
+		  pk rename_column
 
 PG_CONFIG = pg_config
 PGXS := $(shell $(PG_CONFIG) --pgxs)

--- a/expected/type_oid.out
+++ b/expected/type_oid.out
@@ -1,0 +1,66 @@
+\set VERBOSITY terse
+-- predictability
+SET synchronous_commit = on;
+DROP TABLE IF EXISTS tbl;
+CREATE TABLE tbl (a integer, b integer, primary key(a));
+SELECT 'init' FROM pg_create_logical_replication_slot('regression_slot', 'wal2json');
+ ?column? 
+----------
+ init
+(1 row)
+
+INSERT INTO tbl (a, b) VALUES(1,2);
+UPDATE tbl SET a=3;
+DELETE FROM tbl WHERE a=3;
+-- without include-type-oids parameter
+SELECT data FROM pg_logical_slot_peek_changes('regression_slot', NULL, NULL, 'format-version', '1');
+                                                                                                        data                                                                                                         
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {"change":[{"kind":"insert","schema":"public","table":"tbl","columnnames":["a","b"],"columntypes":["integer","integer"],"columnvalues":[1,2]}]}
+ {"change":[{"kind":"update","schema":"public","table":"tbl","columnnames":["a","b"],"columntypes":["integer","integer"],"columnvalues":[3,2],"oldkeys":{"keynames":["a"],"keytypes":["integer"],"keyvalues":[1]}}]}
+ {"change":[{"kind":"delete","schema":"public","table":"tbl","oldkeys":{"keynames":["a"],"keytypes":["integer"],"keyvalues":[3]}}]}
+(3 rows)
+
+SELECT data FROM pg_logical_slot_peek_changes('regression_slot', NULL, NULL, 'format-version', '2');
+                                                                                              data                                                                                               
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {"action":"B"}
+ {"action":"I","schema":"public","table":"tbl","columns":[{"name":"a","type":"integer","value":1},{"name":"b","type":"integer","value":2}]}
+ {"action":"C"}
+ {"action":"B"}
+ {"action":"U","schema":"public","table":"tbl","columns":[{"name":"a","type":"integer","value":3},{"name":"b","type":"integer","value":2}],"identity":[{"name":"a","type":"integer","value":1}]}
+ {"action":"C"}
+ {"action":"B"}
+ {"action":"D","schema":"public","table":"tbl","identity":[{"name":"a","type":"integer","value":3}]}
+ {"action":"C"}
+(9 rows)
+
+-- with include-type-oids parameter
+SELECT data FROM pg_logical_slot_peek_changes('regression_slot', NULL, NULL, 'format-version', '1', 'include-type-oids', '1');
+                                                                                                                              data                                                                                                                               
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {"change":[{"kind":"insert","schema":"public","table":"tbl","columnnames":["a","b"],"columntypes":["integer","integer"],"columntypeoids":[23,23],"columnvalues":[1,2]}]}
+ {"change":[{"kind":"update","schema":"public","table":"tbl","columnnames":["a","b"],"columntypes":["integer","integer"],"columntypeoids":[23,23],"columnvalues":[3,2],"oldkeys":{"keynames":["a"],"keytypes":["integer"],"keytypeoids":[23],"keyvalues":[1]}}]}
+ {"change":[{"kind":"delete","schema":"public","table":"tbl","oldkeys":{"keynames":["a"],"keytypes":["integer"],"keytypeoids":[23],"keyvalues":[3]}}]}
+(3 rows)
+
+SELECT data FROM pg_logical_slot_peek_changes('regression_slot', NULL, NULL, 'format-version', '2', 'include-type-oids', '1');
+                                                                                                                  data                                                                                                                  
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {"action":"B"}
+ {"action":"I","schema":"public","table":"tbl","columns":[{"name":"a","type":"integer","typeoid":23,"value":1},{"name":"b","type":"integer","typeoid":23,"value":2}]}
+ {"action":"C"}
+ {"action":"B"}
+ {"action":"U","schema":"public","table":"tbl","columns":[{"name":"a","type":"integer","typeoid":23,"value":3},{"name":"b","type":"integer","typeoid":23,"value":2}],"identity":[{"name":"a","type":"integer","typeoid":23,"value":1}]}
+ {"action":"C"}
+ {"action":"B"}
+ {"action":"D","schema":"public","table":"tbl","identity":[{"name":"a","type":"integer","typeoid":23,"value":3}]}
+ {"action":"C"}
+(9 rows)
+
+SELECT 'stop' FROM pg_drop_replication_slot('regression_slot');
+ ?column? 
+----------
+ stop
+(1 row)
+

--- a/sql/type_oid.sql
+++ b/sql/type_oid.sql
@@ -1,0 +1,23 @@
+\set VERBOSITY terse
+
+-- predictability
+SET synchronous_commit = on;
+
+DROP TABLE IF EXISTS tbl;
+CREATE TABLE tbl (a integer, b integer, primary key(a));
+
+SELECT 'init' FROM pg_create_logical_replication_slot('regression_slot', 'wal2json');
+
+INSERT INTO tbl (a, b) VALUES(1,2);
+UPDATE tbl SET a=3;
+DELETE FROM tbl WHERE a=3;
+
+-- without include-type-oids parameter
+SELECT data FROM pg_logical_slot_peek_changes('regression_slot', NULL, NULL, 'format-version', '1');
+SELECT data FROM pg_logical_slot_peek_changes('regression_slot', NULL, NULL, 'format-version', '2');
+
+-- with include-type-oids parameter
+SELECT data FROM pg_logical_slot_peek_changes('regression_slot', NULL, NULL, 'format-version', '1', 'include-type-oids', '1');
+SELECT data FROM pg_logical_slot_peek_changes('regression_slot', NULL, NULL, 'format-version', '2', 'include-type-oids', '1');
+
+SELECT 'stop' FROM pg_drop_replication_slot('regression_slot');

--- a/wal2json.c
+++ b/wal2json.c
@@ -2007,6 +2007,15 @@ pg_decode_write_tuple(LogicalDecodingContext *ctx, Relation relation, HeapTuple 
 			ReleaseSysCache(type_tuple);
 		}
 
+		/*
+		 * Print type oid for columns.
+		 */
+		if (data->include_type_oids)
+		{
+			appendStringInfoString(ctx->out, ",\"typeoid\":");
+			appendStringInfo(ctx->out, "%d", attr->atttypid);
+		}
+
 		if (kind != PGOUTPUTJSON_PK)
 		{
 			appendStringInfoString(ctx->out, ",\"value\":");


### PR DESCRIPTION
Currently the `include-type-oids` setting does not include type oids when `format-version` 2 is selected

This PR adds a `typeoid` key to each entry in the `columns` and `identity` objects when `include-type-oids` is `1`

Example output:
```json
{
    "action":"U",
    "schema":"public",
    "table":"tbl",
    "columns": [
        {"name": "a", "type": "integer", "typeoid": 23, "value": 3},
        {"name": "b", "type": "integer", "typeoid": 23, "value": 2}
    ],
    "identity":[
        {"name": "a", "type": "integer", "typeoid": 23, "value": 1}
    ]
}
```

I'm very motivated to get this merged so please let me know if theres anything I can do to make it easier for you to accept the PR. thanks!

resolves #232 