### PR TITLE
Correct DELETED tuple reference pg_decode_change_v1

### DIFF
--- a/wal2json.c
+++ b/wal2json.c
@@ -1817,7 +1817,7 @@ pg_decode_change_v1(LogicalDecodingContext *ctx, ReorderBufferTXN *txn,
 		case REORDER_BUFFER_CHANGE_DELETE:
 			if (data->include_pk && OidIsValid(relation->rd_replidindex) &&
 					relation->rd_rel->relreplident == REPLICA_IDENTITY_DEFAULT)
-				pk_to_stringinfo(ctx, tupdesc, &change->data.tp.newtuple->tuple, pkbs, true);
+				pk_to_stringinfo(ctx, tupdesc, &change->data.tp.oldtuple->tuple, pkbs, true);
 
 			ribs = RelationGetIndexAttrBitmap(relation, INDEX_ATTR_BITMAP_IDENTITY_KEY);
 			identity_to_stringinfo(ctx, tupdesc, &change->data.tp.oldtuple->tuple, ribs);


### PR DESCRIPTION
When I build and run wal2json's regression tests, test "pk" fails and the Postgres backend process crashes with this error:

```
2022-09-21 18:05:54.488 PDT [4251] LOG:  server process (PID 4378) was terminated by signal 4: Illeg
al instruction
2022-09-21 18:05:54.488 PDT [4251] DETAIL:  Failed process was running: SELECT data FROM pg_logical_
slot_peek_changes('regression_slot', NULL, NULL, 'format-version', '1', 'pretty-print', '1', 'includ
e-typmod', '0', 'include-pk', '1');
```

Upon some debugging, I notice that wal2json references `newtuple` under the `REORDER_BUFFER_CHANGE_DELETE` case in `pg_decode_change_v1()` when calling `pk_to_stringinfo()` but it seems like we should use the old tuple. If I replace it with `oldtuple`, the test passes.

Can we confirm if we should pass `oldtuple` to `pk_to_stringinfo()`?