### PR TITLE
Allow the PG_CONFIG environment variable to be used without overridin…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ REGRESS = cmdline insert1 update1 update2 update3 update4 delete1 delete2 \
 		  include_domain_data_type truncate type_oid actions position default \
 		  pk rename_column numeric_data_types_as_string
 
-PG_CONFIG = pg_config
+PG_CONFIG ?= pg_config
 PGXS := $(shell $(PG_CONFIG) --pgxs)
 include $(PGXS)
 


### PR DESCRIPTION
…g it

Otherwise the following command will fail:

$ PG_CONFIG=... make
make: pg_config: No such file or directory
make: *** No targets.  Stop.

Other methods still work:

$ PATH=... make
$ make PG_CONFIG=...