### PR TITLE
Escape the default expression like every other string

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ REGRESS = cmdline insert1 update1 update2 update3 update4 delete1 delete2 \
 		  delete3 delete4 savepoint specialvalue toast bytea message typmod \
 		  filtertable selecttable include_timestamp include_lsn include_xids \
 		  include_domain_data_type truncate type_oid actions position default \
-		  pk rename_column numeric_data_types_as_string partition
+		  default_escape pk rename_column numeric_data_types_as_string partition
 
 # specialvalue test uses Unicode escapes (\uXXXX) whose expected output
 # contains non-ASCII characters, hence, the regression database must be

--- a/expected/default_escape.out
+++ b/expected/default_escape.out
@@ -1,0 +1,53 @@
+\set VERBOSITY terse
+-- predictability
+SET synchronous_commit = on;
+DROP TABLE IF EXISTS xpto;
+CREATE TABLE xpto (
+id			int primary key,
+quote		text DEFAULT 'say "hi"',
+backslash	text DEFAULT 'a\b',
+control		text DEFAULT E'a\tb\nc'
+);
+SELECT 'init' FROM pg_create_logical_replication_slot('regression_slot', 'wal2json');
+ ?column? 
+----------
+ init
+(1 row)
+
+INSERT INTO xpto (id) VALUES (1);
+-- a default expression is escaped like any other string
+SELECT data FROM pg_logical_slot_peek_changes('regression_slot', NULL, NULL, 'format-version', '1', 'include-default', '1');
+                                                                                                                                               data                                                                                                                                               
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {"change":[{"kind":"insert","schema":"public","table":"xpto","columnnames":["id","quote","backslash","control"],"columntypes":["integer","text","text","text"],"columndefaults":[null,"'say \"hi\"'::text","'a\\b'::text","'a\tb\nc'::text"],"columnvalues":[1,"say \"hi\"","a\\b","a\tb\nc"]}]}
+(1 row)
+
+SELECT data FROM pg_logical_slot_peek_changes('regression_slot', NULL, NULL, 'format-version', '2', 'include-default', '1');
+                                                                                                                                                                               data                                                                                                                                                                               
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {"action":"B"}
+ {"action":"I","schema":"public","table":"xpto","columns":[{"name":"id","type":"integer","value":1,"default":null},{"name":"quote","type":"text","value":"say \"hi\"","default":"'say \"hi\"'::text"},{"name":"backslash","type":"text","value":"a\\b","default":"'a\\b'::text"},{"name":"control","type":"text","value":"a\tb\nc","default":"'a\tb\nc'::text"}]}
+ {"action":"C"}
+(3 rows)
+
+-- the emitted lines parse as JSON
+SELECT data::json IS NOT NULL FROM pg_logical_slot_peek_changes('regression_slot', NULL, NULL, 'format-version', '1', 'include-default', '1');
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT data::json IS NOT NULL FROM pg_logical_slot_peek_changes('regression_slot', NULL, NULL, 'format-version', '2', 'include-default', '1');
+ ?column? 
+----------
+ t
+ t
+ t
+(3 rows)
+
+SELECT 'stop' FROM pg_drop_replication_slot('regression_slot');
+ ?column? 
+----------
+ stop
+(1 row)
+

--- a/sql/default_escape.sql
+++ b/sql/default_escape.sql
@@ -1,0 +1,27 @@
+\set VERBOSITY terse
+
+-- predictability
+SET synchronous_commit = on;
+
+DROP TABLE IF EXISTS xpto;
+
+CREATE TABLE xpto (
+id			int primary key,
+quote		text DEFAULT 'say "hi"',
+backslash	text DEFAULT 'a\b',
+control		text DEFAULT E'a\tb\nc'
+);
+
+SELECT 'init' FROM pg_create_logical_replication_slot('regression_slot', 'wal2json');
+
+INSERT INTO xpto (id) VALUES (1);
+
+-- a default expression is escaped like any other string
+SELECT data FROM pg_logical_slot_peek_changes('regression_slot', NULL, NULL, 'format-version', '1', 'include-default', '1');
+SELECT data FROM pg_logical_slot_peek_changes('regression_slot', NULL, NULL, 'format-version', '2', 'include-default', '1');
+
+-- the emitted lines parse as JSON
+SELECT data::json IS NOT NULL FROM pg_logical_slot_peek_changes('regression_slot', NULL, NULL, 'format-version', '1', 'include-default', '1');
+SELECT data::json IS NOT NULL FROM pg_logical_slot_peek_changes('regression_slot', NULL, NULL, 'format-version', '2', 'include-default', '1');
+
+SELECT 'stop' FROM pg_drop_replication_slot('regression_slot');

--- a/wal2json.c
+++ b/wal2json.c
@@ -1316,7 +1316,8 @@ tuple_to_stringinfo(LogicalDecodingContext *ctx, TupleDesc tupdesc, HeapTuple tu
 																	def_value,
 																	ObjectIdGetDatum(relation->rd_id)));
 
-						appendStringInfo(&coldefaults, "%s\"%s\"", comma, result);
+						appendStringInfoString(&coldefaults, comma);
+						escape_json(&coldefaults, result);
 						pfree(result);
 					}
 					else
@@ -2375,7 +2376,7 @@ pg_decode_write_tuple(LogicalDecodingContext *ctx, Relation relation, HeapTuple 
 																	ObjectIdGetDatum(relation->rd_id)));
 
 						appendStringInfoString(ctx->out, ",\"default\":");
-						appendStringInfo(ctx->out, "\"%s\"", result);
+						escape_json(ctx->out, result);
 						pfree(result);
 					}
 					else


### PR DESCRIPTION
With `include-default` enabled, the default expression went into the JSON string wrapped in quotes but never escaped, so a default containing a double quote, a backslash or a control character closes the string early and the whole line is rejected by a JSON parser.

A consumer loses the entire change rather than one field, and cannot repair the byte stream after the fact. Every other string the plugin writes already goes through `escape_json`, so both sites now do the same.

The new test gives a table three such defaults and casts every emitted row to `json`, which fails on its own if an unescaped byte comes back, independently of whether a reader notices the recorded text.

Checked with `make installcheck` on 17.6, 13.22 and 11.22.